### PR TITLE
[NO TICKET] order line item price fix

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -37,7 +37,7 @@ module Spree
                  id = line_item.variant.sku
 
                  lines = flow_order.lines || []
-                 item  = lines.select { |el| el['item_number'] == id }.first
+                 item  = lines.find { |el| el['item_number'] == id }
 
                  return 'n/a' unless item
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -34,12 +34,12 @@ module Spree
     # accepts line item, usually called from views
     def flow_line_item_price(line_item, total = false)
       result = if flow_order
-                 id = line_item.variant.id.to_s
+                 id = line_item.variant.sku
 
                  lines = flow_order.lines || []
                  item  = lines.select { |el| el['item_number'] == id }.first
 
-                 return Flow.price_not_found unless item
+                 return 'n/a' unless item
 
                  total ? item['total']['label'] : item['price']['label']
                else

--- a/lib/flowcommerce_spree/api.rb
+++ b/lib/flowcommerce_spree/api.rb
@@ -45,10 +45,6 @@ module FlowcommerceSpree
       @logger ||= Logger.new('./log/flow.log') # or nil for no logging
     end
 
-    def price_not_found
-      'n/a'
-    end
-
     def format_default_price(amount)
       '$%.2f' % amount
     end


### PR DESCRIPTION
### What problem is the code solving?
When going to a syncrhonized flow order edit page the application is raising an exception like: `NoMethodError: undefined method `price_not_found' for Flow:Module`. This is because the method `Spree::Order#flow_line_item_price` is not able to find the line item associated to the variant and therfore tries calling to the `Flow.price_not_found`

### How does this change address the problem?
Currently the order is storing the line_items information within the `meta` column, and the value stored within the `item_number` is the variant's sku instead of the ID.

Additionally, changing the `Flow#price_not_found` to `n/a`. It is in the only place it is being called so I think we should be ok Hardcoding the 'n/a' here.

### Why is this the best solution?
Seems like it is how it should be working. Another option would be changing the Flow Order's sync method to store the id instead, but I think it is more readable storing the sku.

### Share the knowledge
Example information stored within `meta` for an order within dev5:
```
   "lines"=>
    [{"id"=>"lin-fcef54414aa1449390e17d43eb006aed",
      "price"=>{"base"=>{"label"=>"US$86.71", "amount"=>86.71, "currency"=>"USD"}, "label"=>"71,95 <E2><82><AC>", "amount"=>71.95, "currency"=>"EUR"},
      "total"=>{"base"=>{"label"=>"US$86.71", "amount"=>86.71, "currency"=>"USD"}, "label"=>"71,95 <E2><82><AC>", "amount"=>71.95, "currency"=>"EUR"},
      "quantity"=>1,
      "item_number"=>"p052648"}],
```