### PR TITLE
[TEC-4667] product variant model specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,7 @@ group :development, :test do
   gem 'factory_bot_rails', '~> 4.0'
   gem 'pg', '~> 0.21'
 end
+
+group :test do
+  gem 'database_cleaner'
+end

--- a/spec/dummy/app/models/spree/product_decorator.rb
+++ b/spec/dummy/app/models/spree/product_decorator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Spree
+  Product.class_eval do
+    def master_prices
+      master.prices
+    end
+  end
+end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -39,3 +39,5 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end
+
+Rails.configuration.main_warehouse_id = 5002

--- a/spec/factories/spree/spree_options.rb
+++ b/spec/factories/spree/spree_options.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :option_value, class: Spree::OptionValue do
+    sequence(:name) { |n| "Size-#{n}" }
+
+    presentation { 'S' }
+    option_type
+  end
+
+  factory :option_type, class: Spree::OptionType do
+    sequence(:name) { |n| "foo-size-#{n}" }
+    presentation { 'Size' }
+  end
+end

--- a/spec/factories/spree/spree_products.rb
+++ b/spec/factories/spree/spree_products.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :product, class: Spree::Product do
+    sequence(:name) { |n| "Product ##{n} - #{Kernel.rand(9999)}" }
+    description { 'This is a random description for a product' }
+    price { 19.99 }
+    cost_price { 17.00 }
+    available_on { 1.year.ago }
+    deleted_at { nil }
+    shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
+
+    trait :with_master_variant_flow_data do
+      after(:create) do |product|
+        flow_data = product.master.meta[:flow_data] || {}
+        flow_data[:exp] ||= {}
+        flow_data[:exp][:germany] = {
+          prices: [
+            { key: 'localized_item_price', base: { label: 'US$88.85', amount: 88.85, currency: 'USD' },
+              label: '80.95 €', amount: 80.95, currency: 'EUR', includes: { key: 'vat', label: 'Includes VAT' } }
+          ], status: 'included'
+        }
+        flow_data[:exp][:france] = {
+          prices: [
+            { key: 'localized_item_price', base: { label: 'US$78.85', amount: 78.85, currency: 'USD' },
+              label: '70.95 €', amount: 70.95, currency: 'EUR', includes: { key: 'vat', label: 'Includes VAT' } }
+          ], status: 'included'
+        }
+        product.master.update_columns(meta: { flow_data: flow_data }.to_json)
+
+        germany_zone = Spree::Zones::Product.find_by(name: 'Germany') || create(:germany_zone, :with_flow_data)
+        france_zone = Spree::Zones::Product.find_by(name: 'France') || create(:france_zone, :with_flow_data)
+        product.update_columns(meta: { zone_ids: [germany_zone.id.to_s, france_zone.id.to_s] }.to_json)
+      end
+    end
+
+    trait :with_cad_price do
+      after(:create) do |product|
+        Spree::Price.create(variant_id: Spree::Variant.find_by(product_id: product.id).id,
+                            amount: product.price, currency: 'CAD')
+      end
+    end
+
+    trait :with_aud_price do
+      after(:create) do |product|
+        Spree::Price.create(variant_id: Spree::Variant.find_by(product_id: product.id).id,
+                            amount: product.price, currency: 'AUD')
+      end
+    end
+
+    trait :with_gbp_price do
+      after(:create) do |product|
+        Spree::Price.create(variant_id: Spree::Variant.find_by(product_id: product.id).id,
+                            amount: product.price, currency: 'GBP')
+      end
+    end
+  end
+end

--- a/spec/factories/spree/spree_shipping_categories.rb
+++ b/spec/factories/spree/spree_shipping_categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :shipping_category, class: Spree::ShippingCategory do
+    sequence(:name) { |n| "ShippingCategory ##{n}" }
+  end
+end

--- a/spec/factories/spree/spree_states.rb
+++ b/spec/factories/spree/spree_states.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :state, class: Spree::State do
+    sequence(:name) { |n| "STATE_NAME_#{n}" }
+    sequence(:abbr) { |n| "STATE_ABBR_#{n}" }
+    association :country, factory: :country_with_states
+  end
+end

--- a/spec/factories/spree/spree_stock_locations.rb
+++ b/spec/factories/spree/spree_stock_locations.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :stock_location, class: Spree::StockLocation do
+    id { Rails.configuration.main_warehouse_id }
+    name { 'NY Warehouse' }
+    address1 { '1600 Pennsylvania Ave NW' }
+    city { 'Washington' }
+    zipcode { '20500' }
+    phone { '(202) 456-1111' }
+    active { true }
+    backorderable_default { true }
+
+    country  { |stock_location| Spree::Country.first || stock_location.association(:country) }
+    state do |stock_location|
+      stock_location.country.states.first || stock_location.association(:state, country: stock_location.country)
+    end
+  end
+end

--- a/spec/factories/spree/spree_variants.rb
+++ b/spec/factories/spree/spree_variants.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  sequence(:random_float) { BigDecimal("#{rand(200)}.#{rand(99)}") }
+
+  factory :base_variant, class: Spree::Variant do
+    price { 19.99 }
+    cost_price { 17.00 }
+    sequence(:sku) { |n| "p0000#{n}" }
+    is_master { 0 }
+
+    product { |p| p.association(:product) }
+    option_values { [create(:option_value)] }
+
+    before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
+
+    trait :with_flow_data do
+      after(:create) do |variant|
+        flow_data = variant.meta[:flow_data] || {}
+        flow_data[:exp] ||= {}
+        flow_data[:exp][:germany] = {
+          prices: [
+            { key: 'localized_item_price', base: { label: 'US$88.85', amount: 88.85, currency: 'USD' },
+              label: '80.95 €', amount: 80.95, currency: 'EUR', includes: { key: 'vat', label: 'Includes VAT' } }
+          ], status: 'included'
+        }
+        flow_data[:exp][:france] = {
+          prices: [
+            { key: 'localized_item_price', base: { label: 'US$78.85', amount: 78.85, currency: 'USD' },
+              label: '70.95 €', amount: 70.95, currency: 'EUR', includes: { key: 'vat', label: 'Includes VAT' } }
+          ], status: 'included'
+        }
+        variant.update_columns(meta: { flow_data: flow_data }.to_json)
+
+        germany_zone = Spree::Zones::Product.find_by(name: 'Germany') || create(:germany_zone, :with_flow_data)
+        france_zone = Spree::Zones::Product.find_by(name: 'France') || create(:france_zone, :with_flow_data)
+        variant.product.update_columns(meta: { zone_ids: [germany_zone.id.to_s, france_zone.id.to_s] }.to_json)
+      end
+    end
+
+    trait :with_cad_price do
+      after(:create) do |variant|
+        Spree::Price.create(variant_id: variant.id, amount: variant.product.price, currency: 'CAD')
+      end
+    end
+
+    trait :with_aud_price do
+      after(:create) do |variant|
+        Spree::Price.create(variant_id: variant.id, amount: variant.product.price, currency: 'AUD')
+      end
+    end
+
+    trait :with_gbp_price do
+      after(:create) do |variant|
+        Spree::Price.create(variant_id: variant.id, amount: variant.product.price, currency: 'GBP')
+      end
+    end
+
+    factory :master_variant do
+      is_master { true }
+    end
+  end
+end

--- a/spec/factories/spree/spree_zones.rb
+++ b/spec/factories/spree/spree_zones.rb
@@ -13,7 +13,23 @@ FactoryBot.define do
     end
 
     trait :with_flow_data do
-      meta { { flow_data: { country: 'DEU' } } }
+      meta { { flow_data: { name: 'Germany', key: 'germany', country: 'DEU', currency: 'EUR' } } }
+    end
+  end
+
+  factory :france_zone, class: Spree::Zones::Product do
+    name { 'France' }
+    description { 'France Zone' }
+    status { 'active' }
+
+    zone_members do |proxy|
+      zone = proxy.instance_eval { @instance }
+      country = create(:country, iso: ISO3166::Country.find_country_by_name(name).alpha2)
+      [Spree::ZoneMember.create(zoneable: country, zone: zone)]
+    end
+
+    trait :with_flow_data do
+      meta { { flow_data: { name: 'France', key: 'france', country: 'FRA', currency: 'EUR' } } }
     end
   end
 end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Product, type: :model do
+  describe '#flow_local_price' do
+    describe 'when variant has flow_data' do
+      let(:product) { create(:product, :with_master_variant_flow_data) }
+
+      context 'when experience exists' do
+        let(:experience) { 'germany' }
+
+        it 'returns price in experience currency' do
+          flow_local_price = product.flow_local_price(experience)
+          flow_price_amount = product.master.flow_data['exp'][experience]['prices'][0]['amount']
+
+          expect(flow_local_price.currency).to(eq('EUR'))
+          expect(flow_local_price.price).to(eq(flow_price_amount))
+        end
+      end
+
+      context 'when experience does not exists' do
+        let(:experience) { 'randomcountry' }
+
+        it 'returns price in USD' do
+          variant = product.master
+          flow_local_price = product.flow_local_price(experience)
+
+          expect(variant.meta[:flow_data][:exp].keys).not_to(include(experience))
+          expect(flow_local_price.currency).to(eq('USD'))
+          expect(flow_local_price.price).to(eq(variant.price))
+        end
+      end
+    end
+  end
+
+  describe '#price_in_zone' do
+    describe 'when Spree::Zone has experience in flow' do
+      let(:product) { create(:product, :with_master_variant_flow_data) }
+      let(:spree_zone) { Spree::Zones::Product.find_by(name: 'Germany') }
+      let(:experience) { 'germany' }
+
+      it 'returns price in zone regardles of currency pass' do
+        price_in_zone = product.price_in_zone('USD', spree_zone)
+        flow_price_amount = product.master.flow_data['exp'][experience]['prices'][0]['amount']
+
+        expect(price_in_zone.currency).to(eq('EUR'))
+        expect(price_in_zone.amount).to(eq(flow_price_amount))
+      end
+    end
+
+    context 'when Spree::Zone does not have flow_data' do
+      let(:product) { create(:product, :with_cad_price, :with_aud_price, :with_gbp_price) }
+      let(:spree_zone) { create(:germany_zone) }
+
+      it 'returns price in selected currency' do
+        %w[USD CAD AUD GBP].each do |currency|
+          price_in_zone = product.price_in_zone(currency, spree_zone)
+          variant_price = Spree::Price.find_by(variant_id: product.master.id, currency: currency)
+
+          expect(spree_zone.meta).to(eq({}))
+          expect(price_in_zone.currency).to(eq(currency))
+          expect(price_in_zone.amount).to(eq(variant_price.amount))
+        end
+      end
+    end
+  end
+
+  describe '#price_range' do
+    RSpec.shared_examples 'only_currencies_in_master_variant' do
+      it 'does not return prices in currency not included in master variant' do
+        price_ranges = product.price_range(spree_zone)
+
+        expect(product.master.prices.pluck(:currency)).not_to(include('GBP'))
+        expect(price_ranges['GBP']).to(be_nil)
+      end
+    end
+
+    describe 'when Spree::Zone does has experience in flow' do
+      let(:product) { create(:product, :with_master_variant_flow_data, :with_cad_price, :with_aud_price) }
+      let(:variant1) { create(:base_variant, :with_flow_data, product: product) }
+      let(:variant2) { create(:base_variant, :with_flow_data, product: product) }
+      let(:spree_zone) { Spree::Zones::Product.find_by(name: 'Germany') }
+
+      describe 'when variants have same price' do
+        it 'includes currency for flow experience' do
+          price_ranges = product.price_range(spree_zone)
+          master_flow_price = product.master.flow_local_price(spree_zone.flow_data['key'])
+
+          expect(price_ranges['USD']).to(eq({ amount: product.price.round.to_s }))
+          expect(price_ranges['CAD']).to(eq({ amount: product.price.round.to_s }))
+          expect(price_ranges['AUD']).to(eq({ amount: product.price.round.to_s }))
+          expect(price_ranges['EUR']).to(eq({ amount: master_flow_price.amount.round.to_s }))
+        end
+
+        include_examples 'only_currencies_in_master_variant'
+      end
+
+      describe 'when variants have different prices' do
+        let(:min_price) { 100 }
+        let(:max_price) { 1000 }
+
+        before(:each) do
+          variant1.meta[:flow_data][:exp][:germany][:prices][0][:amount] = min_price
+          variant1.update_columns(meta: variant1.meta.to_json)
+
+          variant2.meta[:flow_data][:exp][:germany][:prices][0][:amount] = max_price
+          variant2.update_columns(meta: variant2.meta.to_json)
+        end
+
+        it 'returns price ranges for currencies' do
+          price_ranges = product.price_range(spree_zone)
+
+          expect(price_ranges['EUR']).to(eq({ min: min_price.to_s, max: max_price.to_s }))
+        end
+
+        include_examples 'only_currencies_in_master_variant'
+      end
+    end
+
+    describe 'when Spree::Zone does not have experience in flow' do
+      let(:product) { create(:product, :with_cad_price, :with_aud_price) }
+      let(:variant1) { create(:base_variant, product: product) }
+      let(:variant2) { create(:base_variant, product: product) }
+      let(:spree_zone) { Spree::Zones::Product.find_by(name: 'Germany') }
+
+      describe 'when variants have same price' do
+        it 'returns amount for each currency' do
+          price_ranges = product.price_range(spree_zone)
+          expect(price_ranges['USD']).to(eq({ amount: product.price.round.to_s }))
+          expect(price_ranges['CAD']).to(eq({ amount: product.price.round.to_s }))
+          expect(price_ranges['AUD']).to(eq({ amount: product.price.round.to_s }))
+        end
+
+        include_examples 'only_currencies_in_master_variant'
+      end
+
+      describe 'when variants have different prices' do
+        let(:min_price) { 100 }
+        let(:max_price) { 1000 }
+
+        before(:each) do
+          %w[USD CAD AUD GBP].each do |currency|
+            Spree::Price.find_or_create_by(variant_id: variant1.id, currency: currency)
+                        .update_attribute(:amount, min_price)
+            Spree::Price.find_or_create_by(variant_id: variant2.id, currency: currency)
+                        .update_attribute(:amount, max_price)
+          end
+        end
+
+        it 'returns price ranges for currencies' do
+          price_ranges = product.price_range(spree_zone)
+          expect(price_ranges['USD']).to(eq({ min: min_price.to_s, max: max_price.to_s }))
+          expect(price_ranges['CAD']).to(eq({ min: min_price.to_s, max: max_price.to_s }))
+          expect(price_ranges['AUD']).to(eq({ min: min_price.to_s, max: max_price.to_s }))
+        end
+
+        include_examples 'only_currencies_in_master_variant'
+      end
+    end
+  end
+end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Variant, type: :model do
+  describe '#truncate_flow_data' do
+    context 'when variant has flow_data' do
+      let(:variant) { create(:base_variant, :with_flow_data) }
+      let(:spree_zone) { Spree::Zones::Product.find_by(name: 'Germany') }
+
+      it 'deletes flow data' do
+        variant.truncate_flow_data
+        expect(variant.flow_data).to(be_nil)
+      end
+
+      it 'removes product from Spree::Zones' do
+        expect(variant.product.zone_ids).to(be_present)
+        variant.truncate_flow_data
+        expect(variant.product.zone_ids).to(be_empty)
+      end
+    end
+  end
+
+  describe '#remove_experience_from_product' do
+    context 'when variant has multiple experiences assocaited' do
+      let(:variant) { create(:base_variant, :with_flow_data) }
+      let(:spree_zone) { Spree::Zones::Product.find_by(name: 'Germany') }
+      let(:spree_zone2) { Spree::Zones::Product.find_by(name: 'France') }
+
+      it 'removes only the experience defined' do
+        expect(variant.product.zone_ids).to(match_array([spree_zone.id.to_s, spree_zone2.id.to_s]))
+        variant.remove_experience_from_product('germany', variant.product)
+
+        expect(variant.product.zone_ids).to(be_present)
+        expect(variant.product.zone_ids).to(match_array([spree_zone2.id.to_s]))
+      end
+    end
+  end
+
+  describe '#flow_local_price' do
+    describe 'when variant has flow_data' do
+      let(:variant) { create(:base_variant, :with_flow_data) }
+
+      context 'when experience exists' do
+        let(:experience) { 'germany' }
+
+        it 'returns price in experience currency' do
+          flow_local_price = variant.flow_local_price(experience)
+          flow_price_amount = variant.flow_data['exp'][experience]['prices'][0]['amount']
+
+          expect(flow_local_price.currency).to(eq('EUR'))
+          expect(flow_local_price.price).to(eq(flow_price_amount))
+        end
+      end
+
+      context 'when experience does not exists' do
+        let(:experience) { 'randomcountry' }
+
+        it 'returns price in USD' do
+          flow_local_price = variant.flow_local_price(experience)
+
+          expect(variant.meta[:flow_data][:exp].keys).not_to(include(experience))
+          expect(flow_local_price.currency).to(eq('USD'))
+          expect(flow_local_price.price).to(eq(variant.price))
+        end
+      end
+    end
+  end
+
+  describe '#price_in_zone' do
+    describe 'when Spree::Zone has experience in flow' do
+      let(:variant) { create(:base_variant, :with_flow_data) }
+      let(:spree_zone) { Spree::Zones::Product.find_by(name: 'Germany') }
+      let(:experience) { 'germany' }
+
+      it 'returns price in zone regardles of currency pass' do
+        price_in_zone = variant.price_in_zone('USD', spree_zone)
+        flow_price_amount = variant.flow_data['exp'][experience]['prices'][0]['amount']
+
+        expect(price_in_zone.currency).to(eq('EUR'))
+        expect(price_in_zone.amount).to(eq(flow_price_amount))
+      end
+    end
+
+    context 'when Spree::Zone does not have flow_data' do
+      let(:variant) { create(:base_variant, :with_cad_price, :with_aud_price, :with_gbp_price) }
+      let(:spree_zone) { create(:germany_zone) }
+
+      it 'returns price in selected currency' do
+        %w[USD CAD AUD GBP].each do |currency|
+          price_in_zone = variant.price_in_zone(currency, spree_zone)
+          variant_price = Spree::Price.find_by(variant_id: variant.id, currency: currency)
+
+          expect(spree_zone.meta).to(eq({}))
+          expect(price_in_zone.currency).to(eq(currency))
+          expect(price_in_zone.amount).to(eq(variant_price.amount))
+        end
+      end
+    end
+  end
+
+  describe '#all_prices_in_zone' do
+    describe 'when variant has flow_data' do
+      let(:variant) { create(:base_variant, :with_flow_data) }
+
+      context 'when zone has flow experience' do
+        it 'includes flow price' do
+          spree_zone = create(:germany_zone, :with_flow_data)
+          all_prices = variant.all_prices_in_zone(spree_zone)
+
+          flow_price = variant.flow_local_price('germany')
+          expect(all_prices).to(include({ amount: variant.price.round.to_s, currency: 'USD' }))
+          expect(all_prices).to(include({ amount: flow_price.amount.round.to_s, currency: flow_price.currency }))
+        end
+      end
+
+      context 'when zone does not have flow experience' do
+        it 'does not include flow price' do
+          spree_zone = create(:germany_zone)
+          all_prices = variant.all_prices_in_zone(spree_zone)
+
+          flow_price = variant.flow_local_price('germany')
+          expect(all_prices).to(include({ amount: variant.price.round.to_s, currency: 'USD' }))
+          expect(all_prices).not_to(include({ amount: flow_price.amount.round.to_s, currency: flow_price.currency }))
+        end
+      end
+    end
+
+    context 'when variant does not have flow_data' do
+      let(:variant) { create(:base_variant) }
+
+      it 'returns all_prices' do
+        spree_zone = create(:germany_zone)
+        all_prices = variant.all_prices_in_zone(spree_zone)
+
+        expect(all_prices).to(eq([{ amount: variant.price.round.to_s, currency: 'USD' }]))
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,9 +5,11 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('dummy/config/environment', __dir__)
 
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'ffaker'
 require 'support/factory_bot'
+require 'support/database_cleaner.rb'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -41,7 +43,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
### What problem is the code solving?
Adding a little more coverage along with some factories that will come in handy for future specs.

### How does this change address the problem?
- Adding new specs for Spree::Variant and Spree::Product methods.
- Adding some new factories for products, variants and related records.
- Configuring database_cleaner to properly keep the DB clean between specs.

### Why is this the best solution?
We need to increase coverage.

### Share the knowledge
Nothing worth mentioning.