### PR TITLE
Fix the use of bundler by GitHub Actions and adding gemspec to the Gemfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,13 +33,13 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler: 1.17.3
+          bundler-cache: true
       - name: Install postgres client
         run: sudo apt-get install libpq-dev
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install libcurl3-dev
-          bundle install
       - name: Create database
         run: |
           bundle exec rake db:create RAILS_ENV=test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,20 +25,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2.1.3
-        with: 
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}  
+        with:
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           path: vendor/bundle
       - uses: ruby/setup-ruby@master
         id: ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
+          bundler: 1.17.3
       - name: Install postgres client
         run: sudo apt-get install libpq-dev
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install libcurl3-dev
-          gem install bundler -v 1.17.3
           bundle install
       - name: Create database
         run: |
@@ -48,9 +48,9 @@ jobs:
           bundle exec rake db:schema:load RAILS_ENV=test
       - name: Run tests
         run: REPORT_COVERAGE=true bundle exec rspec
-      - name: Upload coverage results  
+      - name: Upload coverage results
         uses: actions/upload-artifact@master
-        if: always()	
+        if: always()
         with:
           name: coverage
           path: coverage

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :development, :test do
   gem 'byebug'
   gem 'countries'
   gem 'factory_bot_rails', '~> 4.0'
-  gem 'pg', '~> 0.21'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
+gemspec
+
 group :development, :test do
   gem 'dotenv-rails', require: 'dotenv/rails-now'
 

--- a/flowcommerce_spree.gemspec
+++ b/flowcommerce_spree.gemspec
@@ -9,8 +9,8 @@ require 'flowcommerce_spree/version'
 Gem::Specification.new do |s|
   s.name        = 'flowcommerce_spree'
   s.version     = FlowcommerceSpree::VERSION
-  s.authors     = ['Aurel Branzeanu']
-  s.email       = ['a.branzeanu@datarockets.com']
+  s.authors     = ['Aurel Branzeanu', 'Sebastian De Luca']
+  s.email       = ['a.branzeanu@datarockets.com', 'sebastian.deluca@mejuri.com']
   s.homepage    = 'https://github.com/mejuri-inc/flowcommerce_spree'
   s.summary     = 'Integration of Spree with Flow API'
   s.description = 'Integration of popular Rails/Spree store framework with e-commerce Flow API'
@@ -23,10 +23,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'colorize'
   s.add_dependency 'concurrent-ruby', '~> 1.0', '>= 1.1.7'
   s.add_dependency 'flowcommerce'
-  # s.add_dependency 'flowcommerce-activemerchant'
   s.add_dependency 'flowcommerce-reference'
   s.add_dependency 'oj'
+  s.add_dependency 'pg', '~> 0.21'
   s.add_dependency 'spree_backend', '~> 2.3.0'
-
-  s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
### What problem is the code solving?

We were manually installing bundler 1.17.3 version, but the `ruby/setup-ruby` action was using by default the latest version of bundler, which is not compatible with Rails 4.1.x, causing failures.

Also, the gemspec hasn't been added to the Gemfile, which was causing wrong dependency management by the bundler.

### How does this change address the problem?

Specifying bundler 1.17.3 version to be used by the `ruby/setup-ruby` action and adding gemspec to the Gemfile.

Also added `bundler-cache` to be used by `ruby/setup-ruby` to boost the action start time.
