### PR TITLE
[NO TICKET] persists flow address

### DIFF
--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -2,10 +2,10 @@
 
 module Spree
   Address.class_eval do
-    def update_attributes_from_params(address_data)
+    def prepare_from_flow_attributes(address_data)
       self.attributes = {
-        first_name: address_data.dig('name', 'first'),
-        last_name: address_data.dig('name', 'last'),
+        first_name: address_data['first'],
+        last_name: address_data['last'],
         phone: address_data['phone'],
         address1: address_data['streets'][0],
         address2: address_data['streets'][1],

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Spree
+  Address.class_eval do
+    def update_attributes_from_params(address_data)
+      self.attributes = {
+        first_name: address_data.dig('name', 'first'),
+        last_name: address_data.dig('name', 'last'),
+        phone: address_data['phone'],
+        address1: address_data['streets'][0],
+        address2: address_data['streets'][1],
+        zipcode: address_data['postal'],
+        city: address_data['city'],
+        state_name: address_data['province'] || 'something',
+        country: Spree::Country.find_by(iso3: address_data['country'])
+      }
+    end
+  end
+end

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -106,10 +106,13 @@ module FlowcommerceSpree
             attrs_to_update[:state] = 'complete'
             attrs_to_update[:payment_state] = 'paid'
             attrs_to_update[:completed_at] = Time.zone.now.utc
+            attrs_to_update[:email] = order.flow_customer_email
           else
             attrs_to_update[:state] = 'confirmed'
           end
         end
+
+        attrs_to_update.merge!(order.prepare_flow_addresses) if order.complete? || attrs_to_update[:state] == 'complete'
 
         order.update_columns(attrs_to_update)
         order.create_tax_charge! if flow_data_submitted

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Order, type: :model do
+  describe '#prepare_flow_addresses' do
+    context 'when order flow_io data' do
+      let(:order) { create(:order, :with_flow_data) }
+      let(:flow_destination) do
+        { 'city' => 'Aachen',
+          'postal' => '52064',
+          'contact' => { 'name' => { 'last' => 'Test', 'first' => 'Random' },
+                         'email' => 'test@mailiniator.com', 'phone' => '1234567890' },
+          'country' => 'DEU',
+          'streets' => ['Karlsgraben 15'] }
+      end
+      let(:flow_payments) do
+        [{ 'id' => 'opm-2d5aab2bd81649bfae4a9a5269bac270',
+           'date' => '2021-02-01T19:42:29.445Z',
+           'type' => 'card',
+           'total' => { 'base' => { 'label' => 'US$115.22', 'amount' => 115.22, 'currency' => 'USD' },
+                        'label' => '96,80 <E2><82><AC>', 'amount' => 96.8, 'currency' => 'EUR' },
+           'address' => { 'city' => 'Aachen', 'name' => { 'last' => 'Test', 'first' => 'Random' },
+                          'postal' => '52064', 'country' => 'DEU', 'streets' => ['Karlsgraben 15'] },
+           'reference' => 'aut-Hxh73jeU9OBynuNwsb7iKzDQlOvMXBRK',
+           'attributes' => {},
+           'description' => 'VISA 4242',
+           'merchant_of_record' => 'flow' }]
+      end
+
+      before(:each) do
+        create(:country, iso3: 'DEU')
+        flow_data = order.flow_data
+        flow_data[:order][:destination] = flow_destination
+        flow_data[:order][:payments] = flow_payments
+        order.flow_data = flow_data
+        order.save
+      end
+
+      context 'when address does not exists for order' do
+        it 'sets ship_address based on customer information' do
+          expect { order.prepare_flow_addresses }.to(change(Spree::Address, :count).by(2))
+          expect(order.ship_address).to(be_present)
+        end
+
+        it 'sets bill_address based on payment information' do
+          expect { order.prepare_flow_addresses }.to(change(Spree::Address, :count).by(2))
+          expect(order.bill_address).to(be_present)
+        end
+      end
+
+      context 'when order already has address created' do
+        before(:each) { order.prepare_flow_addresses }
+
+        it 'updates current ship address' do
+          new_street = 'Gartenstrasse'
+          order.flow_data['order']['destination']['streets'][0] = new_street
+          order.save
+          expect { order.prepare_flow_addresses }.to(change(Spree::Address, :count).by(0))
+          expect(order.ship_address.address1).to(eq(new_street))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem is the code solving?
Adding methods to create ship and bill address for Flow Orders.

### How does this change address the problem?
- Adding new **flow_ship_address** and **flow_bill_address** methods to Spree::Order that returns a Spree::Address record with information loaded from Flow's data stored in meta.
- Adding new **prepare_flow_addresses** method to Spree::Order that creates/update the Spree::Address records based on flow information stored in the meta tag and returns the records's IDs, which the webhook uses to update the order. This is done this way in order to reduce the amount of DB calls made.
- Extending webhook **hook_order_upserted_v2** to call prepare_flow_addresses and set the order's email based on flow data.

### Why is this the best solution?
We should save the ship and bill address associated to the order if we want Spree and Fulfill integration to work properly.

### Share the knowledge
The **flow_ship_address** and **flow_bill_address** defaults the state_name to the string 'something'. This is to avoid validation errors with countries where the state is required but Flow does not require that field on their form.