### PR TITLE
[TEC-4453] Adding Flow IO Shipping calcualtor and renaming tax calculator to match naming convention

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem 'devise'
   gem 'dotenv-rails', require: 'dotenv/rails-now'
   gem 'factory_bot_rails', '~> 4.0'
+  gem 'hashie'
   gem 'oj', '= 3.7.12'
   gem 'rails', '4.1.16'
   gem 'rspec-rails', '~> 3.5'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ group :development, :test do
   gem 'devise'
   gem 'dotenv-rails', require: 'dotenv/rails-now'
   gem 'factory_bot_rails', '~> 4.0'
-  gem 'hashie'
   gem 'oj', '= 3.7.12'
   gem 'rails', '4.1.16'
   gem 'rspec-rails', '~> 3.5'

--- a/app/models/spree/calculator/flow_io.rb
+++ b/app/models/spree/calculator/flow_io.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class Calculator
-    class FlowcommerceCalculator < Calculator::DefaultTax
+    class FlowIo < Calculator::DefaultTax
       def self.description
         'FlowCommerce Calculator'
       end

--- a/app/models/spree/calculator/flow_io.rb
+++ b/app/models/spree/calculator/flow_io.rb
@@ -4,7 +4,7 @@ module Spree
   class Calculator
     class FlowIo < Calculator::DefaultTax
       def self.description
-        'FlowCommerce Calculator'
+        'FlowIO Calculator'
       end
 
       def compute_shipment_or_line_item(item)

--- a/app/models/spree/calculator/shipping/flow_io.rb
+++ b/app/models/spree/calculator/shipping/flow_io.rb
@@ -12,7 +12,7 @@ module Spree
           flow_order = flow_order(package)
           return unless flow_order
 
-          flow_order&.prices&.find { |x| x.key('shipping') }&.amount || 0
+          flow_order['prices'].find { |x| x['key'] == 'shipping' }['amount'] || 0
         end
 
         def default_charge(_country)
@@ -28,7 +28,7 @@ module Spree
         def flow_order(package)
           return @flow_order if defined?(@flow_order)
 
-          @flow_order = package.order.flow_order
+          @flow_order = package.order.flow_data&.[]('order')
           @flow_order
         end
       end

--- a/app/models/spree/calculator/shipping/flow_io.rb
+++ b/app/models/spree/calculator/shipping/flow_io.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Spree
+  module Calculator::Shipping
+    class FlowIo < ShippingCalculator
+      preference :lower_boundary, :decimal, default: 100
+
+      def self.description
+        'FlowCommerce'
+      end
+
+      def compute_package(package)
+        flow_order = flow_order(package)
+        return unless flow_order
+
+        flow_order&.prices&.find { |x| x.key('shipping') }&.amount || 0
+      end
+
+      def threshold
+        preferred_lower_boundary
+      end
+
+      private
+
+      def flow_order(package)
+        return @flow_order if defined?(@flow_order)
+
+        @flow_order = package.order.flow_order
+        @flow_order
+      end
+    end
+  end
+end

--- a/app/models/spree/calculator/shipping/flow_io.rb
+++ b/app/models/spree/calculator/shipping/flow_io.rb
@@ -1,32 +1,36 @@
 # frozen_string_literal: true
 
 module Spree
-  module Calculator::Shipping
-    class FlowIo < ShippingCalculator
-      preference :lower_boundary, :decimal, default: 100
+  class Calculator
+    module Shipping
+      class FlowIo < ShippingCalculator
+        def self.description
+          'FlowIO Calculator'
+        end
 
-      def self.description
-        'FlowCommerce'
-      end
+        def compute_package(package)
+          flow_order = flow_order(package)
+          return unless flow_order
 
-      def compute_package(package)
-        flow_order = flow_order(package)
-        return unless flow_order
+          flow_order&.prices&.find { |x| x.key('shipping') }&.amount || 0
+        end
 
-        flow_order&.prices&.find { |x| x.key('shipping') }&.amount || 0
-      end
+        def default_charge(_country)
+          0
+        end
 
-      def threshold
-        preferred_lower_boundary
-      end
+        def threshold
+          0
+        end
 
-      private
+        private
 
-      def flow_order(package)
-        return @flow_order if defined?(@flow_order)
+        def flow_order(package)
+          return @flow_order if defined?(@flow_order)
 
-        @flow_order = package.order.flow_order
-        @flow_order
+          @flow_order = package.order.flow_order
+          @flow_order
+        end
       end
     end
   end

--- a/app/services/flowcommerce_spree/order_sync.rb
+++ b/app/services/flowcommerce_spree/order_sync.rb
@@ -245,7 +245,7 @@ module FlowcommerceSpree
       @use_get = false
 
       # use get if order is completed and closed
-      @use_get = true if @order.flow_data['order']['submitted_at'].present? || @order.state == 'complete'
+      @use_get = true if @order.flow_data.dig('order', 'submitted_at').present? || @order.state == 'complete'
 
       # use get if local digest hash check said there is no change
       @use_get ||= true if @order.flow_data['digest'] == @digest

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -27,9 +27,13 @@ RemoveUnusedMethodsInControllersCheck: { except_methods: [] }
 RemoveUnusedMethodsInHelpersCheck: { except_methods: [] }
 RemoveUnusedMethodsInModelsCheck: { except_methods: 
   [
-  'Spree::FlowcommerceCalculator#compute_shipment', # Used by Spree::Calculator
-  'Spree::FlowcommerceCalculator#compute_line_item', # Used by Spree::Calculator
-  'Spree::FlowcommerceCalculator#description', # Used by Spree
+  'Spree::Calculator::FlowIo#compute_shipment', # Used by Spree::Calculator
+  'Spree::Calculator::FlowIo#compute_line_item', # Used by Spree::Calculator
+  'Spree::Calculator::FlowIo#description', # Used by Spree
+  'Spree::Shipping::FlowIo#compute_package', # Used by Spree
+  'Spree::Shipping::FlowIo#default_charge', # Used by Spree
+  'Spree::Shipping::FlowIo#threshold', # Used by Spree
+  'Spree::Shipping::FlowIo#description', # Used by Spree
   ] }
 ReplaceComplexCreationWithFactoryMethodCheck: { attribute_assignment_count: 2 }
 ReplaceInstanceVariableWithLocalVariableCheck: { }

--- a/lib/flowcommerce_spree/engine.rb
+++ b/lib/flowcommerce_spree/engine.rb
@@ -45,7 +45,8 @@ module FlowcommerceSpree
     config.to_prepare(&method(:activate).to_proc)
 
     initializer 'spree.flowcommerce_spree.calculators', after: 'spree.register.calculators' do |_app|
-      Rails.application.config.spree.calculators.tax_rates << Spree::Calculator::FlowcommerceCalculator
+      Rails.application.config.spree.calculators.tax_rates << Spree::Calculator::FlowIo
+      Rails.application.config.spree.calculators.shipping_methods << Spree::Calculator::Shipping::FlowIo
     end
   end
 end

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -125,6 +125,7 @@ module FlowcommerceSpree
 
         order.update_columns(attrs_to_update)
 
+        # TODO: To be refactored once we have the capture_upserted_v2 webhook configured
         if flow_data_submitted
           order.create_tax_charge!
           order.finalize!

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -124,7 +124,12 @@ module FlowcommerceSpree
         end
 
         order.update_columns(attrs_to_update)
-        order.create_tax_charge! if flow_data_submitted
+
+        if flow_data_submitted
+          order.create_tax_charge!
+          order.finalize!
+        end
+
         return order
       else
         errors << { message: "Order #{order_number} not found" }

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -128,6 +128,7 @@ module FlowcommerceSpree
         if flow_data_submitted
           order.create_tax_charge!
           order.finalize!
+          order.update_totals
         end
 
         return order

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -128,7 +128,7 @@ module FlowcommerceSpree
         if flow_data_submitted
           order.create_tax_charge!
           order.finalize!
-          order.update_totals
+          order.reload.update_totals
         end
 
         return order

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -116,10 +116,13 @@ module FlowcommerceSpree
         end
 
         attrs_to_update.merge!(order.prepare_flow_addresses) if order.complete? || attrs_to_update[:state] == 'complete'
+
         order.create_proposed_shipments
+        order.shipment.update_amounts
 
         order.update_columns(attrs_to_update)
         order.create_tax_charge! if flow_data_submitted
+
         return order
       else
         errors << { message: "Order #{order_number} not found" }

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -117,12 +117,14 @@ module FlowcommerceSpree
 
         attrs_to_update.merge!(order.prepare_flow_addresses) if order.complete? || attrs_to_update[:state] == 'complete'
 
-        order.create_proposed_shipments
-        order.shipment.update_amounts
+        if flow_data_submitted
+          order.create_proposed_shipments
+          order.shipment.update_amounts
+          order.line_items.each(&:store_ets)
+        end
 
         order.update_columns(attrs_to_update)
         order.create_tax_charge! if flow_data_submitted
-
         return order
       else
         errors << { message: "Order #{order_number} not found" }

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -128,7 +128,8 @@ module FlowcommerceSpree
         if flow_data_submitted
           order.create_tax_charge!
           order.finalize!
-          order.reload.update_totals
+          order.update_totals
+          order.save
         end
 
         return order

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -116,6 +116,7 @@ module FlowcommerceSpree
         end
 
         attrs_to_update.merge!(order.prepare_flow_addresses) if order.complete? || attrs_to_update[:state] == 'complete'
+        order.create_proposed_shipments
 
         order.update_columns(attrs_to_update)
         order.create_tax_charge! if flow_data_submitted

--- a/spec/factories/spree/spree_calculators.rb
+++ b/spec/factories/spree/spree_calculators.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
     after(:create) { |c| c.set_preference(:amount, 10.0) }
   end
 
+  factory :shipping_flow_io_calculator, class: Spree::Calculator::Shipping::FlowIo do
+    after(:create) { |c| c.set_preference(:lower_boundary, 3) }
+  end
+
   factory :default_tax_calculator, class: Spree::Calculator::DefaultTax do
   end
 end

--- a/spec/factories/spree/spree_orders.rb
+++ b/spec/factories/spree/spree_orders.rb
@@ -53,7 +53,29 @@ FactoryBot.define do
              'total' => { 'base' => { 'label' => 'US$88.85', 'amount' => 88.85, 'currency' => 'USD' },
                           'label' => '80.95 €', 'amount' => 80.95, 'currency' => 'EUR' },
              'quantity' => 2,
-             'item_number' => 'p52505531' }] }
+             'item_number' => 'p52505531' }],
+          'prices' =>
+          [{ 'key' => 'shipping',
+             'currency' => 'EUR',
+             'amount' => 283.3,
+             'label' => '283,30 €',
+             'base' => { 'amount' => 338.3, 'currency' => 'USD', 'label' => 'US$338.30' },
+             'components' =>
+              [{ 'key' => 'shipping', 'currency' => 'EUR', 'amount' => 283.3, 'label' => '283,30 €', 'base' =>
+                { 'amount' => 338.3, 'currency' => 'USD', 'label' => 'US$338.30' }, 'name' => 'Shipping' },
+               { 'key' => 'vat_deminimis', 'currency' => 'EUR', 'amount' => -6.46,
+                 'label' => '-6,46 €', 'base' => { 'amount' => -7.71, 'currency' => 'USD', 'label' => '-US$7.71' },
+                 'name' => 'VAT de minimis adjustment' },
+               { 'key' => 'vat_duties_freight', 'currency' => 'EUR', 'amount' => 6.46,
+                 'label' => '6,46 €', 'base' => { 'amount' => 7.71, 'currency' => 'USD', 'label' => 'US$7.71' },
+                 'name' => 'VAT on duties on freight' },
+               { 'key' => 'vat_freight', 'currency' => 'EUR', 'amount' => 53.83, 'label' => '53,83 €', 'base' =>
+               { 'amount' => 64.28, 'currency' => 'USD', 'label' => 'US$64.28' }, 'name' => 'VAT on freight' },
+               { 'key' => 'vat_subsidy', 'currency' => 'EUR', 'amount' => -53.83,
+                 'label' => '-53,83 €', 'base' => { 'amount' => -64.28, 'currency' => 'USD', 'label' => '-US$64.28' },
+                 'name' => 'VAT subsidy' }],
+             'accuracy' => 'calculated',
+             'name' => 'Shipping' }] }
         } }
       end
     end

--- a/spec/factories/spree/spree_shipments.rb
+++ b/spec/factories/spree/spree_shipments.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :shipment, class: Spree::Shipment do
+  factory :base_shipment, class: Spree::Shipment do
     tracking { 'U10000' }
     cost { 100.00 }
     state { 'pending' }
@@ -11,8 +11,6 @@ FactoryBot.define do
     end
 
     after(:create) do |shipment|
-      shipment.add_shipping_method(create(:shipping_method), true)
-
       shipment.order.line_items.each do |line_item|
         line_item.quantity.times do
           shipment.inventory_units.create(
@@ -20,6 +18,18 @@ FactoryBot.define do
             line_item_id: line_item.id
           )
         end
+      end
+    end
+
+    factory :shipment do
+      after(:create) do |shipment|
+        shipment.add_shipping_method(create(:shipping_method), true)
+      end
+    end
+
+    factory :flow_shipment do
+      after(:create) do |shipment|
+        shipment.add_shipping_method(create(:flow_shipping_method), true)
       end
     end
   end

--- a/spec/factories/spree/spree_shipping_methods.rb
+++ b/spec/factories/spree/spree_shipping_methods.rb
@@ -18,5 +18,9 @@ FactoryBot.define do
     factory :shipping_method, class: Spree::ShippingMethod do
       association(:calculator, factory: :shipping_calculator, strategy: :build)
     end
+
+    factory :flow_shipping_method, class: Spree::ShippingMethod do
+      association(:calculator, factory: :shipping_flow_io_calculator, strategy: :build)
+    end
   end
 end

--- a/spec/models/spree/calculator/flow_io_spec.rb
+++ b/spec/models/spree/calculator/flow_io_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'support/flowcommerce_example_response'
 
-RSpec.describe Spree::Calculator::FlowcommerceCalculator, type: :model do
+RSpec.describe Spree::Calculator::FlowIo, type: :model do
   describe '#compute' do
     context 'when taxes and duties are included in price' do
       let(:tax_rate) { create(:included_tax_rate) }

--- a/spec/models/spree/calculator/shipping/flow_io_spec.rb
+++ b/spec/models/spree/calculator/shipping/flow_io_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Spree::Calculator::Shipping::FlowIo, type: :model do
       let(:package) { double(Spree::Stock::Package, order: order) }
 
       it 'returns amount from flow_io info' do
-        expected_amount = package.order.flow_order&.prices&.find { |x| x.key('shipping') }&.amount
+        expected_amount = package.order.flow_data.dig('order', 'prices')&.find { |x| x.key('shipping') }&.[]('amount')
         expect(subject.compute_package(package)).to(be(expected_amount))
       end
     end

--- a/spec/models/spree/calculator/shipping/flow_io_spec.rb
+++ b/spec/models/spree/calculator/shipping/flow_io_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Calculator::Shipping::FlowIo, type: :model do
+  describe '#compute_package' do
+    context 'when order does not have flow_io data' do
+      let(:order) { create(:order_with_line_items) }
+      let(:package) { double(Spree::Stock::Package, order: order) }
+
+      it 'returns amount from flow_io info' do
+        expect(subject.compute_package(package)).to(be(nil))
+      end
+    end
+
+    context 'when order has flow_io data' do
+      let(:order) { create(:order_with_line_items, :with_flow_data) }
+      let(:package) { double(Spree::Stock::Package, order: order) }
+
+      it 'returns amount from flow_io info' do
+        expected_amount = package.order.flow_order&.prices&.find { |x| x.key('shipping') }&.amount
+        expect(subject.compute_package(package)).to(be(expected_amount))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem is the code solving?
For orders that are associated to a Flow Experience, the shipping is not being handled/calculated within Spree. Flow will be processing the order on their side and sharing the order's details with Spree, which are stored in the `meta` column. Spree needs to create the shipping for the order using that information retrieved from Flow.

### How does this change address the problem?
- Adding a new Shipping Calculator that Spree will use to create the shipment based on Flow's information stored within the order's `meta` column.
- Configuring webhook order_upseart_v2 to perform the following actions:
  - create proposed shipments : Using the Spree::Stock::Coordinator will create the shipments, and thanks to the ShowroomSplitter it will also update the line item's stock_location_id.
  - update shipments amount : This has to be called in order to set the shipment's cost column based on the Shipment Calculator. 
  - finalize the order : This is to trigger the stock allocation for the order as well as other calls such as updating order's shipping/payment status and closing adjusmtnts.

### Why is this the best solution?
Having calculators to handle such logic is the most accurate way to handle this, helping with decoupling of Flow logic from other entities.

### Share the knowledge
Within this PR we are also renaming Tax calculator to a name more accurate. We are using Flowio in other places within the flowcommerce_spree so it would be better to keep the same convention.