### PR TITLE
[NO-TICKET] defauling FLOW_TOKEN environment variable to avoid errors

### DIFF
--- a/lib/flowcommerce_spree.rb
+++ b/lib/flowcommerce_spree.rb
@@ -12,9 +12,6 @@ require 'flow/simple_gateway'
 require 'request_store'
 
 module FlowcommerceSpree
-  API_KEY = ENV.fetch('FLOW_TOKEN', 'test_key')
-  ENV['FLOW_TOKEN'] = API_KEY
-
   def self.client(logger: FlowcommerceSpree.logger, **opts)
     FlowCommerce.instance(http_handler: LoggingHttpHandler.new(logger: logger), **opts)
   end

--- a/lib/flowcommerce_spree.rb
+++ b/lib/flowcommerce_spree.rb
@@ -12,6 +12,9 @@ require 'flow/simple_gateway'
 require 'request_store'
 
 module FlowcommerceSpree
+  API_KEY = ENV.fetch('FLOW_TOKEN', 'test_key')
+  ENV['FLOW_TOKEN'] = API_KEY
+
   def self.client(logger: FlowcommerceSpree.logger, **opts)
     FlowCommerce.instance(http_handler: LoggingHttpHandler.new(logger: logger), **opts)
   end

--- a/lib/flowcommerce_spree/engine.rb
+++ b/lib/flowcommerce_spree/engine.rb
@@ -9,7 +9,6 @@ module FlowcommerceSpree
       FlowcommerceSpree::ORGANIZATION = ENV.fetch('FLOW_ORGANIZATION', 'flow.io')
       FlowcommerceSpree::BASE_COUNTRY = ENV.fetch('FLOW_BASE_COUNTRY', 'USA')
       FlowcommerceSpree::API_KEY = ENV.fetch('FLOW_TOKEN', 'test_key')
-      ENV['FLOW_TOKEN'] = FlowcommerceSpree::API_KEY
 
       FlowcommerceSpree::Config = FlowcommerceSpree::Settings.new
     end

--- a/lib/flowcommerce_spree/engine.rb
+++ b/lib/flowcommerce_spree/engine.rb
@@ -9,6 +9,7 @@ module FlowcommerceSpree
       FlowcommerceSpree::ORGANIZATION = ENV.fetch('FLOW_ORGANIZATION', 'flow.io')
       FlowcommerceSpree::BASE_COUNTRY = ENV.fetch('FLOW_BASE_COUNTRY', 'USA')
       FlowcommerceSpree::API_KEY = ENV.fetch('FLOW_TOKEN', 'test_key')
+      ENV['FLOW_TOKEN'] = FlowcommerceSpree::API_KEY
 
       FlowcommerceSpree::Config = FlowcommerceSpree::Settings.new
     end


### PR DESCRIPTION
### What problem is the code solving?
When trying to run the application within an environment where it does not have any FLOW related environment variable set it raises an error.

### How does this change address the problem?
By forcing the ENV['FLOW_TOKEN'] to a default value. 

### Why is this the best solution?
The best solution would be to have a way of somehow configuring to avoid running any single line of code associated to Flow if the environment variable is not set; However I did not find any easy way of doing it.

Setting this default value in the initializer we make sure that it will be available. The issue is that we are using flowcommerce ruby-sdk gem, which requires this FLOW_TOKEN to be present (https://github.com/flowcommerce/ruby-sdk/blob/master/lib/flow_commerce/client.rb). Having this default will not stop Spree from trying calls, but at least it will not explode.

### Share the knowledge
nothing worth mentioning here.