### PR TITLE
[TEC-4792] Configuring price_range to return min/max only

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,35 +57,59 @@ All flowcommerce_spree code is located in the ./app and ./lib folders.
   `serialize :flow_data, ActiveRecord::Coders::JSON.new(symbolize_keys: true)`
  
 
+## FlowcommerceSpree::Api module
 
-## Flow API specific
-
-Classes that begin with Flow are responsible for communicating with flow API.
-
-### Flow
-
-Helper class that offers low level flow api access and few helper methods.
+This is a legacy module using the `curl` gem for making direct calls to flow.io API. It will be refactored out in 
+future versions of the gem in favor of using the official flow.io API client from the `flowcommerce` gem.
 
 ### FlowcommerceSpree::ExperienceService
 
 Responsible for selecting current experience. You have to define available experiences in flow console.
 
-### Flow::Order
+### FlowcommerceSpree::OrderSync
 
 Maintain and synchronizes Spree::Order with Flow API.
 
-### Flow::Session
+### FlowcommerceSpree::Session
 
 Every shop user has a session. This class helps in creating and maintaining session with Flow.
 
-## Decorators
+### Decorators
 
-Decorators are found in ./app/flow/decorators folders and they decorate Spree models with Flow specific methods.
-
-All methods are prefixed with ```flow_```.
-
-## Helper lib
+Decorators are used extensively across the gem to modify or add behaviour of several Spree classes and modules. To 
+properly deal with the precedence in the Ruby ancestor chain, the `class_eval`, `include` and `prepend` methods are 
+being used, depending on the level of modification.
 
 ### Spree::Flow::Gateway
 
 Adapter for Spree, that allows using [Flow.io](https://www.flow.io) as payment gateway. Flow is PCI compliant payment processor.
+
+## Gem Maintenance
+
+### RubyGems credentials
+
+Ensure you have the RubyGems credentials located in the `~/.gem/credentials` file.
+
+### Adding a gem owner
+
+```
+gem owner flowcommerce_spree -a sebastian.deluca@mejuri.com
+```
+
+### Building a new gem version
+
+Adjust the new gem version number in the `lib/flowcommerce_spree/version.rb` file. It is used when building the gem 
+by the following command:
+
+```
+gem build flowcommerce_spree.gemspec
+```
+
+Asuming the version was set to `0.0.1`, a `flowcommerce_spree-0.0.1.gem` will be generated at the root of the app 
+(repo).
+
+### Pushing a new gem release to RubyGems
+
+```
+gem push flowcommerce_spree-0.0.1.gem # don't forget to specify the correct version number
+```

--- a/app/models/spree/flow_io_product_decorator.rb
+++ b/app/models/spree/flow_io_product_decorator.rb
@@ -49,7 +49,7 @@ module Spree
         rmin = min&.amount&.to_s(:rounded, precision: 0) || 0
         rmax = max&.amount&.to_s(:rounded, precision: 0) || 0
 
-        prices[currency] = rmin == rmax ? { amount: rmin } : { min: rmin, max: rmax }
+        prices[currency] = { min: rmin, max: rmax }
       end
 
       add_flow_price_range(prices, product_zone)
@@ -82,7 +82,7 @@ module Spree
       rmin = min&.amount&.to_s(:rounded, precision: 0) || 0
       rmax = max&.amount&.to_s(:rounded, precision: 0) || 0
 
-      prices[currency] = rmin == rmax ? { amount: rmin } : { min: rmin, max: rmax }
+      prices[currency] = { min: rmin, max: rmax }
       prices
     end
 

--- a/lib/flowcommerce_spree/version.rb
+++ b/lib/flowcommerce_spree/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlowcommerceSpree
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -85,12 +85,13 @@ RSpec.describe Spree::Product, type: :model do
       describe 'when variants have same price' do
         it 'includes currency for flow experience' do
           price_ranges = product.price_range(spree_zone)
-          master_flow_price = product.master.flow_local_price(spree_zone.flow_data['key'])
+          master_flow_price = product.master.flow_local_price(spree_zone.flow_data['key']).amount.round.to_s
 
-          expect(price_ranges['USD']).to(eq({ amount: product.price.round.to_s }))
-          expect(price_ranges['CAD']).to(eq({ amount: product.price.round.to_s }))
-          expect(price_ranges['AUD']).to(eq({ amount: product.price.round.to_s }))
-          expect(price_ranges['EUR']).to(eq({ amount: master_flow_price.amount.round.to_s }))
+          price_range_hash = { max: product.price.round.to_s, min: product.price.round.to_s }
+          expect(price_ranges['USD']).to(eq(price_range_hash))
+          expect(price_ranges['CAD']).to(eq(price_range_hash))
+          expect(price_ranges['AUD']).to(eq(price_range_hash))
+          expect(price_ranges['EUR']).to(eq(max: master_flow_price, min: master_flow_price))
         end
 
         include_examples 'only_currencies_in_master_variant'
@@ -127,9 +128,10 @@ RSpec.describe Spree::Product, type: :model do
       describe 'when variants have same price' do
         it 'returns amount for each currency' do
           price_ranges = product.price_range(spree_zone)
-          expect(price_ranges['USD']).to(eq({ amount: product.price.round.to_s }))
-          expect(price_ranges['CAD']).to(eq({ amount: product.price.round.to_s }))
-          expect(price_ranges['AUD']).to(eq({ amount: product.price.round.to_s }))
+          price_range_hash = { max: product.price.round.to_s, min: product.price.round.to_s }
+          expect(price_ranges['USD']).to(eq(price_range_hash))
+          expect(price_ranges['CAD']).to(eq(price_range_hash))
+          expect(price_ranges['AUD']).to(eq(price_range_hash))
         end
 
         include_examples 'only_currencies_in_master_variant'


### PR DESCRIPTION
### What problem is the code solving?
We are aiming to have in production these changes https://github.com/mejuri-inc/mejuri-web/pull/775. However; The version v0.0.1 is decorating that method and therefore the changes from https://github.com/mejuri-inc/mejuri-web/pull/775 are not being applied. These changes have been included into flowcommerce_spree within the `develop` branch which are not ready to be pushed into production yet.

The main issue is that we want to go live with these changes today (February 18th 2021) but we cannot use `develop` branch. 

### How does this change address the problem?
Introducing changes from commit https://github.com/mejuri-inc/flowcommerce_spree/pull/16/commits/b94821f0bd66d82b79cfe56d2ec58466b91e742e (from develop branch) for a temporary usage.

### Why is this the best solution?
The easiest solution to have these changes until the new version of flowcommerce_spree goes live.