### PR TITLE
[TEC-4958] base changes to handle thank you page redirection

### DIFF
--- a/app/controllers/flowcommerce_spree/orders_controller.rb
+++ b/app/controllers/flowcommerce_spree/orders_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module FlowcommerceSpree
+  class OrdersController < ApplicationController
+    wrap_parameters false
+
+    skip_before_action :setup_tracking, only: :order_completed
+
+    # proxy enpoint between flow and thankyou page.
+    # /flow/order_completed endpoint
+    def order_completed
+      flow_updater = FlowcommerceSpree::OrderUpdater.new(order: current_order)
+      flow_updater.complete_checkout
+
+      redirect_to '/thankyou', { order: params[:order], token: params[:token] }
+    end
+  end
+end

--- a/app/controllers/flowcommerce_spree/orders_controller.rb
+++ b/app/controllers/flowcommerce_spree/orders_controller.rb
@@ -12,7 +12,7 @@ module FlowcommerceSpree
       flow_updater = FlowcommerceSpree::OrderUpdater.new(order: current_order)
       flow_updater.complete_checkout
 
-      redirect_to "/thankyou?order=#{params[:order]}&t=#{params[:token]}"
+      redirect_to "/thankyou?order=#{params[:order]}&t=#{params[:t]}"
     end
   end
 end

--- a/app/controllers/flowcommerce_spree/orders_controller.rb
+++ b/app/controllers/flowcommerce_spree/orders_controller.rb
@@ -12,7 +12,7 @@ module FlowcommerceSpree
       flow_updater = FlowcommerceSpree::OrderUpdater.new(order: current_order)
       flow_updater.complete_checkout
 
-      redirect_to '/thankyou', { order: params[:order], token: params[:token] }
+      redirect_to "/thankyou?order=#{params[:order]}&t=#{params[:token]}"
     end
   end
 end

--- a/app/services/flowcommerce_spree/order_sync.rb
+++ b/app/services/flowcommerce_spree/order_sync.rb
@@ -187,7 +187,7 @@ module FlowcommerceSpree
     def refresh_checkout_token
       root_url = url_helpers.root_url
       order_number = @order.number
-      confirmation_url = "#{root_url}thankyou?order=#{order_number}&t=#{@order.guest_token}"
+      confirmation_url = "#{root_url}flow/order-completed?order=#{order_number}&t=#{@order.guest_token}"
       checkout_token = FlowcommerceSpree.client.checkout_tokens.post_checkout_and_tokens_by_organization(
         FlowcommerceSpree::ORGANIZATION,
         discriminator: 'checkout_token_reference_form',

--- a/app/services/flowcommerce_spree/order_updater.rb
+++ b/app/services/flowcommerce_spree/order_updater.rb
@@ -18,12 +18,7 @@ module FlowcommerceSpree
       @order.flow_data['order'] = flow_io_order
       attrs_to_update = { meta: @order.meta.to_json }
       if @order.flow_data.dig('order', 'submitted_at').present? && !@order.complete?
-        # flow_io_total_amount = order.flow_io_total_amount&.to_d
-        # attrs_to_update[:total] = flow_io_total_amount if flow_io_total_amount != order.total
-        # attrs_to_update[:updated_at] = Time.zone.now.utc
-
         attrs_to_update[:email] = @order.flow_customer_email
-        # attrs_to_update[:state] = 'confirmed'
         attrs_to_update[:payment_state] = 'pending'
         attrs_to_update.merge!(@order.prepare_flow_addresses)
         @order.state = 'delivery'
@@ -37,7 +32,6 @@ module FlowcommerceSpree
       end
 
       @order.update_columns(attrs_to_update)
-      puts 'Order Updated'
       @order.save!
     end
 

--- a/app/services/flowcommerce_spree/order_updater.rb
+++ b/app/services/flowcommerce_spree/order_updater.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module FlowcommerceSpree
+  class OrderUpdater
+    def initialize(order:)
+      raise(ArgumentError, 'Experience not defined or not active') unless order.zone&.flow_io_active_experience?
+
+      @experience = order.flow_io_experience_key
+      @order = order
+      @client = FlowcommerceSpree.client
+    end
+
+    def upsert_data(flow_io_order = nil)
+      flow_io_order ||= @client.orders.get_by_number(FlowcommerceSpree::ORGANIZATION, @order.number).to_hash
+
+      Rails.logger "[!] Flow IO Order data #{flow_io_order}"
+
+      @order.flow_data['order'] = flow_io_order
+      attrs_to_update = { meta: @order.meta.to_json }
+      if @order.flow_data.dig('order', 'submitted_at').present? && !@order.complete?
+        # flow_io_total_amount = order.flow_io_total_amount&.to_d
+        # attrs_to_update[:total] = flow_io_total_amount if flow_io_total_amount != order.total
+        # attrs_to_update[:updated_at] = Time.zone.now.utc
+
+        attrs_to_update[:email] = @order.flow_customer_email
+        # attrs_to_update[:state] = 'confirmed'
+        attrs_to_update[:payment_state] = 'pending'
+        attrs_to_update.merge!(@order.prepare_flow_addresses)
+        @order.state = 'delivery'
+        @order.save!
+        @order.create_proposed_shipments
+        @order.shipment.update_amounts
+        @order.line_items.each(&:store_ets)
+        @order.charge_taxes
+
+        # TODO : Add payment mapping
+      end
+
+      @order.update_columns(attrs_to_update)
+      puts 'Order Updated'
+      @order.save!
+    end
+
+    def finalize_order
+      @order.finalize!
+      @order.update_totals
+      @order.save
+      @order.after_completed_order
+    end
+
+    def complete_checkout
+      upsert_data
+
+      @order.state = 'complete'
+      @order.save
+
+      finalize_order
+    end
+  end
+end

--- a/app/services/flowcommerce_spree/order_updater.rb
+++ b/app/services/flowcommerce_spree/order_updater.rb
@@ -3,7 +3,7 @@
 module FlowcommerceSpree
   class OrderUpdater
     def initialize(order:)
-      raise(ArgumentError, 'Experience not defined or not active') unless order.zone&.flow_io_active_experience?
+      raise(ArgumentError, 'Experience not defined or not active') unless order&.zone&.flow_io_active_experience?
 
       @experience = order.flow_io_experience_key
       @order = order
@@ -21,8 +21,6 @@ module FlowcommerceSpree
         attrs_to_update[:email] = @order.flow_customer_email
         attrs_to_update[:payment_state] = 'pending'
         attrs_to_update.merge!(@order.prepare_flow_addresses)
-        # @order.state = 'delivery'
-        # @order.save!
         @order.create_proposed_shipments
         @order.shipment.update_amounts
         @order.line_items.each(&:store_ets)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@
 
 FlowcommerceSpree::Engine.routes.draw do
   post '/event-target', to: 'webhooks#handle_flow_web_hook_event'
+  get '/order-completed', to: 'orders#order_completed'
 end

--- a/lib/flowcommerce_spree/engine.rb
+++ b/lib/flowcommerce_spree/engine.rb
@@ -24,7 +24,7 @@ module FlowcommerceSpree
 
       app.config.flowcommerce_spree[:mounted_path] = ENV.fetch('FLOW_MOUNT_PATH', '/flow')
 
-      app.routes.append do
+      app.routes.prepend do
         mount FlowcommerceSpree::Engine => app.config.flowcommerce_spree[:mounted_path]
       end
     end

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -172,22 +172,10 @@ module FlowcommerceSpree
     end
 
     def upsert_order(flow_io_order, order)
-      return if order.state == 'complete'
+      order_updater = FlowcommerceSpree::OrderUpdater.new(order: order)
+      order_updater.upsert_order(flow_io_order)
 
-      order.flow_data['order'] = flow_io_order.to_hash
-      return if order.flow_data.dig('order', 'submitted_at').blank?
-
-      attrs_to_update = { meta: order.meta.to_json, email: order.flow_customer_email, payment_state: 'pending' }
-      attrs_to_update.merge!(order.prepare_flow_addresses)
-      order.state = 'delivery'
-      order.save!
-      order.create_proposed_shipments
-      order.shipment.update_amounts
-      order.line_items.each(&:store_ets)
-      order.charge_taxes
-
-      order.update_columns(attrs_to_update)
-      order.state = 'payment'
+      order.state = 'confirm'
       order.save!
     end
 
@@ -235,6 +223,7 @@ module FlowcommerceSpree
         payment.complete
       end
 
+<<<<<<< HEAD
       return unless order.flow_io_captures_sum >= order.flow_io_total_amount && order.flow_io_balance_amount <= 0
 
       order.finalize!
@@ -244,6 +233,12 @@ module FlowcommerceSpree
       order.update_totals
       order.save
       order.after_completed_order
+=======
+      return if order.complete?
+      return unless order.flow_io_captures_sum >= order.flow_io_total_amount && order.flow_io_balance_amount <= 0
+
+      FlowcommerceSpree::OrderUpdater.new(order).finalize_order
+>>>>>>> [TEC-4958] base changes to handle thank you page redirection
     end
 
     def payment_method_id

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -205,7 +205,7 @@ module FlowcommerceSpree
       order.save!
     end
 
-    def map_payment_captures_to_spree(order) # rubocop:disable Metrics/AbcSize
+    def map_payment_captures_to_spree(order)
       payments = order.flow_data&.dig('order', 'payments')
       order.flow_data['captures']&.each do |c|
         next unless c['status'] == 'succeeded'
@@ -223,22 +223,10 @@ module FlowcommerceSpree
         payment.complete
       end
 
-<<<<<<< HEAD
-      return unless order.flow_io_captures_sum >= order.flow_io_total_amount && order.flow_io_balance_amount <= 0
-
-      order.finalize!
-
-      return if order.completed?
-
-      order.update_totals
-      order.save
-      order.after_completed_order
-=======
       return if order.complete?
       return unless order.flow_io_captures_sum >= order.flow_io_total_amount && order.flow_io_balance_amount <= 0
 
       FlowcommerceSpree::OrderUpdater.new(order).finalize_order
->>>>>>> [TEC-4958] base changes to handle thank you page redirection
     end
 
     def payment_method_id

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -205,7 +205,7 @@ module FlowcommerceSpree
       order.save!
     end
 
-    def map_payment_captures_to_spree(order)
+    def map_payment_captures_to_spree(order) # rubocop:disable Metrics/AbcSize
       payments = order.flow_data&.dig('order', 'payments')
       order.flow_data['captures']&.each do |c|
         next unless c['status'] == 'succeeded'

--- a/spec/controllers/flowcommerce_spree/orders_controller_spec.rb
+++ b/spec/controllers/flowcommerce_spree/orders_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FlowcommerceSpree::OrdersController, type: :controller do
+  let(:zone) { create(:germany_zone, :with_flow_data) }
+  let(:order) { create(:order_with_line_items, :with_flow_data) }
+
+  describe '#order_completed' do
+    context 'when order is associated to flow zone' do
+      before do
+        allow(controller).to receive(:current_order).and_return(order)
+        expect(zone).to(receive(:flow_io_active_experience?).and_return(true))
+        expect(order).to(receive(:zone).and_return(zone))
+        expect_any_instance_of(FlowcommerceSpree::OrderUpdater).to(receive(:complete_checkout))
+      end
+
+      subject { spree_get :order_completed, order: order.number, t: order.guest_token }
+
+      it 'redirects to thank you page' do
+        expect(subject).to(redirect_to("/thankyou?order=#{order.number}&t=#{order.guest_token}"))
+      end
+    end
+  end
+end

--- a/spec/flowcommerce_spree/order_updater_spec.rb
+++ b/spec/flowcommerce_spree/order_updater_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FlowcommerceSpree::OrderUpdater do
+  let(:zone) { create(:germany_zone, :with_flow_data) }
+  let(:order) { create(:order_with_line_items, :with_flow_data) }
+
+  context 'when order is not present' do
+    subject { FlowcommerceSpree::OrderUpdater.new(order: nil) }
+
+    it 'raises exception' do
+      expect { subject }.to(raise_error.with_message('Experience not defined or not active'))
+    end
+  end
+
+  context 'when order is not assocaited to flow experience' do
+    before do
+      allow(zone).to(receive(:flow_io_active_experience?).and_return(false))
+      allow(order).to(receive(:zone).and_return(zone))
+    end
+
+    subject { FlowcommerceSpree::OrderUpdater.new(order: order) }
+
+    it 'raises exception' do
+      expect { subject }.to(raise_error.with_message('Experience not defined or not active'))
+    end
+  end
+end

--- a/spec/flowcommerce_spree/webhook_service_spec.rb
+++ b/spec/flowcommerce_spree/webhook_service_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FlowcommerceSpree::WebhookService do
+  let(:order) { create(:order_with_line_items, :with_flow_data) }
+
+  describe '#process' do
+    context 'when hook does not exists' do
+      it 'returns error message' do
+        discriminator = 'test_hook'
+        webhook_service = FlowcommerceSpree::WebhookService.new({ 'discriminator' => discriminator })
+
+        response = webhook_service.process
+        expect(response.errors).to(eq([{ message: "No hook for #{discriminator}" }]))
+      end
+    end
+  end
+end

--- a/spec/flowcommerce_spree/webhook_service_spec.rb
+++ b/spec/flowcommerce_spree/webhook_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FlowcommerceSpree::WebhookService do
     context 'when hook does not exists' do
       it 'returns error message' do
         discriminator = 'test_hook'
-        webhook_service = FlowcommerceSpree::WebhookService.new({ 'discriminator' => discriminator })
+        webhook_service = FlowcommerceSpree::WebhookService.new('discriminator' => discriminator)
 
         response = webhook_service.process
         expect(response.errors).to(eq([{ message: "No hook for #{discriminator}" }]))

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,7 @@ require 'ffaker/utils/unique_utils' # TODO: Remove on ffaker v.2.7.0, where it w
 require 'support/factory_bot'
 require 'support/database_cleaner.rb'
 require 'support/flow.rb'
+require 'support/controller_requests.rb'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -67,6 +68,8 @@ RSpec.configure do |config|
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
+
+  config.include ControllerRequests
 
   config.include Devise::Test::ControllerHelpers, type: :controller
   # arbitrary gems may also be filtered via:

--- a/spec/support/controller_requests.rb
+++ b/spec/support/controller_requests.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ControllerRequests
+  def spree_get(action, parameters = nil, session = nil, flash = nil)
+    process_spree_action(action, parameters, session, flash, 'GET')
+  end
+
+  # Executes a request simulating POST HTTP method and set/volley the response
+  def spree_post(action, parameters = nil, session = nil, flash = nil)
+    process_spree_action(action, parameters, session, flash, 'POST')
+  end
+
+  # Executes a request simulating PUT HTTP method and set/volley the response
+  def spree_put(action, parameters = nil, session = nil, flash = nil)
+    process_spree_action(action, parameters, session, flash, 'PUT')
+  end
+
+  # Executes a request simulating DELETE HTTP method and set/volley the response
+  def spree_delete(action, parameters = nil, session = nil, flash = nil)
+    process_spree_action(action, parameters, session, flash, 'DELETE')
+  end
+
+  private
+
+  def process_spree_action(action, parameters = nil, session = nil, flash = nil, method = 'GET')
+    parameters ||= {}
+    process(action, method, parameters.merge!(use_route: :spree), session, flash)
+  end
+end


### PR DESCRIPTION
### What problem is the code solving?
For orders associated to a Flow experience we are using Flow's checkout; however, upon completing the checkout the user is redirected to our Thank you page hosted in Mejuri FE.

All the information submitted in the Flow's checkout is being propagated to Spree thanks to webhooks; However, some of these webhooks can take up to 5 minutes according to Flow, which might generate unwanted experiences for the user. Like seeing their order still open.

### How does this change address the problem?
- Adding a new proxy endpoint `/flow/order-completed` between Flow and our Thank you page. This endpoint will update the order's information by calling Flow's API and then proceed to complete the order before redirecting the user to our thank you page.
- For this endpoint to be available we need to prepend Flow routes instead of append. This is because in mejuri-web we have configured a `get '/*path'` which was capturing the HTTP get request instead of the route added in this gem.
- Since there is shared logic between webhooks and this proxy endpoint, we are adding a new entity named **FlowcommerceSpree::OrderUpdater**. This is only to place shared code that can be easily called from both places, and should eventually be properly refactored.
- Within webhooks `map_payments_to_spree` had to be sligthly changed to avoid setting the order in status 'payment'. This is because this method was ran after the thank you page and was wrongly updating the order (leaving it in payment status). 

### Why is this the best solution?
Having this proxy endpoint between Flow's checkout and our Thank you page was the only way we could find to avoid depending on webhooks to close the order. It should be the correct way as well since we are completing the order with the current available information, and in case there is an update related to payment caputres/fraud analyss the webhooks will let us know.

### Share the knowledge
- **WIP** There are missing specs. I will be working on adding them.
- Thanks to the "Order Upserted V2" webhook, there is a chance that when the user completes the checkout Spree already has all the information from flow, and therefore it might not be necessary to pull all the order's information at that point. At this moment the proxy endpoint is currently requesting the order's information ALWAYS, but it could be eventually improved if we find that it is generating performance issues.