### PR TITLE
[TEC-4525] Create refund method for flow.io gateway

### DIFF
--- a/app/models/spree/flow_io_order_decorator.rb
+++ b/app/models/spree/flow_io_order_decorator.rb
@@ -175,7 +175,6 @@ module Spree
 
     def flow_io_captures_sum
       captures_sum = 0
-      # flow_data&.[]('captures')&.select { |c| c['status'] == 'succeeded' }&.map { |c| c['amount'] }&.sum.to_d
       flow_data&.[]('captures')&.each do |c|
         next if c['status'] != 'succeeded'
 

--- a/app/models/spree/gateway/flow_io.rb
+++ b/app/models/spree/gateway/flow_io.rb
@@ -5,6 +5,8 @@
 module Spree
   class Gateway
     class FlowIo < Gateway
+      REFUND_SUCCESS = 'succeeded'
+
       def provider_class
         self.class
       end
@@ -56,9 +58,26 @@ module Spree
         end
       end
 
-      def refund(_money, _authorization_key, options = {})
-        order = load_order options
-        order.cc_refund
+      def refund(payment, amount, _options = {})
+        order = payment.order
+        refund_form =
+          Io::Flow::V0::Models::RefundForm.new(order_number: order.number, amount: amount, currency: order.currency)
+        response = FlowcommerceSpree.client.refunds.post(FlowcommerceSpree::ORGANIZATION, refund_form)
+        response_status = response.status.value
+        if response_status == REFUND_SUCCESS
+          refund = response.to_hash
+          order.flow_data['refunds'] ||= []
+          order_refunds = order.flow_data['refunds']
+          order_refunds.delete_if { |r| r['id'] == response.id }
+          order_refunds << refund
+          order.update_column(:meta, order.meta.to_json)
+          ActiveMerchant::Billing::Response.new(true, REFUND_SUCCESS, {}, {})
+        else
+          msg = "Partial refund fail. Details: #{response_status}"
+          ActiveMerchant::Billing::Response.new(false, msg, {}, {})
+        end
+      rescue StandardError => e
+        ActiveMerchant::Billing::Response.new(false, e, {}, {})
       end
 
       def void(money, authorization_key, options = {})

--- a/app/models/spree/gateway/flow_io.rb
+++ b/app/models/spree/gateway/flow_io.rb
@@ -72,7 +72,7 @@ module Spree
           ActiveMerchant::Billing::Response.new(false, msg, {}, {})
         end
       rescue StandardError => e
-        ActiveMerchant::Billing::Response.new(false, e, {}, {})
+        ActiveMerchant::Billing::Response.new(false, e.to_s, {}, {})
       end
 
       def void(money, authorization_key, options = {})
@@ -90,6 +90,7 @@ module Spree
       private
 
       def add_refund_to_order(response, order)
+        order.flow_data ||= {}
         order.flow_data['refunds'] ||= []
         order_refunds = order.flow_data['refunds']
         order_refunds.delete_if { |r| r['id'] == response.id }

--- a/lib/flow/simple_gateway.rb
+++ b/lib/flow/simple_gateway.rb
@@ -54,22 +54,6 @@ module Flow
       error_response(e)
     end
 
-    def cc_refund
-      raise ArgumentError, 'capture info is not available' unless @order.flow_data['capture']
-
-      # we allways have capture ID, so we use it
-      refund_data = { capture_id: @order.flow_data['capture']['id'] }
-      refund_form = ::Io::Flow::V0::Models::RefundForm.new(refund_data)
-      response    = FlowcommerceSpree.client.refunds.post(FlowcommerceSpree::ORGANIZATION, refund_form)
-
-      return ActiveMerchant::Billing::Response.new false, 'error', response: response unless response.id
-
-      @order.update_column :flow_data, @order.flow_data.merge('refund': response.to_hash)
-      ActiveMerchant::Billing::Response.new true, 'success', response: response
-    rescue StandardError => e
-      error_response(e)
-    end
-
     private
 
     # if order is not in flow, we use local Spree settings

--- a/lib/flowcommerce_spree/logging_http_client.rb
+++ b/lib/flowcommerce_spree/logging_http_client.rb
@@ -24,7 +24,8 @@ module FlowcommerceSpree
       begin
         response = super
       rescue Io::Flow::V0::HttpClient::ServerError => e
-        @error = { error: e }.to_json
+        @error = { error: Oj.load(e.body), code: e.code, status: e.details }
+        raise StandardError, @error.dig(:error, 'messages')
       ensure
         # client.open_timeout = original_open
         # client.read_timeout = original_read
@@ -38,7 +39,7 @@ module FlowcommerceSpree
           "Completed #{request.method} #{request.path} #{duration} ms\n"
         )
 
-        @logger.info "Error: #{e.inspect}" if e
+        @logger.info "Error: #{@error.inspect}" if @error
       end
     end
   end

--- a/lib/flowcommerce_spree/webhook_service.rb
+++ b/lib/flowcommerce_spree/webhook_service.rb
@@ -147,13 +147,6 @@ module FlowcommerceSpree
       self
     end
 
-    # send en email when order is refunded
-    def refund_upserted_v2
-      Spree::OrderMailer.refund_complete_email(@data).deliver
-
-      'Email delivered'
-    end
-
     def map_payment_captures_to_spree(order)
       payments = order.flow_data&.dig('order', 'payments')
       order.flow_data['captures']&.each do |c|

--- a/spec/factories/flow_io/authorization_reference.rb
+++ b/spec/factories/flow_io/authorization_reference.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flow_authorization_reference, class: Io::Flow::V0::Models::AuthorizationReference do
+    id { Faker::Guid.guid }
+    key { id }
+    order { { number: Faker::Guid.guid } }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/factories/flow_io/capture.rb
+++ b/spec/factories/flow_io/capture.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flow_capture, class: Io::Flow::V0::Models::Capture do
+    id { Faker::Guid.guid }
+    key { id }
+    authorization { build(:flow_authorization_reference) }
+    requested { build(:flow_money) }
+    amount { requested.amount }
+    currency { requested.currency.to_s }
+    status { 'succeeded' }
+    created_at { Time.now.utc }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/factories/flow_io/money.rb
+++ b/spec/factories/flow_io/money.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flow_money, class: Io::Flow::V0::Models::Money do
+    amount { rand(0..100) }
+    currency { Faker::Currency.code }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/factories/flow_io/refund.rb
+++ b/spec/factories/flow_io/refund.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flow_refund, class: Io::Flow::V0::Models::Refund do
+    id { Faker::Guid.guid }
+    key { id }
+    authorization { build(:flow_authorization_reference) }
+    status { 'succeeded' }
+    created_at { Time.now.utc }
+    captures do
+      capture = build(:flow_capture)
+      [{ capture: capture.to_hash, amount: capture.amount }]
+    end
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/factories/spree/gateway/flow_io.rb
+++ b/spec/factories/spree/gateway/flow_io.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flow_io_gateway, class: Spree::Gateway::FlowIo do
+    name { 'flow.io' }
+    environment { 'test' }
+  end
+end

--- a/spec/factories/spree/spree_payments.rb
+++ b/spec/factories/spree/spree_payments.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :payment, class: Spree::Payment do
+    order
+    response_code { Faker::Guid.guid }
+  end
+
+  trait :completed do
+    state { 'completed' }
+  end
+
+  trait :void do
+    state { 'void' }
+  end
+end

--- a/spec/models/spree/gateway/flow_io_spec.rb
+++ b/spec/models/spree/gateway/flow_io_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Gateway::FlowIo do
+  let(:gateway) { create(:flow_io_gateway) }
+
+  describe '#provider_class' do
+    it 'returns provider`s class`' do
+      expect(gateway.provider_class.name).to eql('Spree::Gateway::FlowIo')
+    end
+  end
+
+  describe '#refund' do
+    let(:order) { create(:order_with_line_items) }
+    let(:payment) { create(:payment, order: order, payment_method_id: gateway.id) }
+    let(:amount) { order.item_total }
+    let(:refund) { build(:flow_refund, currency: order.currency, amount: amount) }
+
+    context 'when refund has succeeded' do
+      before do
+        allow(FlowcommerceSpree).to receive_message_chain(:client, :refunds, :post).and_return(refund)
+      end
+
+      it 'returns a successful ActiveMerchant::Billing::Response and ads refund to the order`s flow_data' do
+        allow(gateway).to receive(:add_refund_to_order).and_call_original
+        expect(gateway).to receive(:add_refund_to_order).with(refund, order)
+
+        result = gateway.refund(payment, amount)
+
+        expect(result).to be_instance_of(ActiveMerchant::Billing::Response)
+        expect(result.message).to eql(Spree::Gateway::FlowIo::REFUND_SUCCESS)
+        expect(result.success?).to eql(true)
+
+        order.reload
+        order_refunds = order.flow_data['refunds']
+        expect(order_refunds).to be_instance_of(Array)
+
+        order_refund = order_refunds.first
+        order_refund_captures = order_refund.delete('captures')
+        expect(order_refund_captures).to be_instance_of(Array)
+
+        refund_capture = order_refund_captures.first['capture']
+        expect(order_refund.except('created_at'))
+          .to eql(refund.to_hash.except(:captures, :created_at).deep_stringify_keys!)
+        expect(refund_capture.except('created_at'))
+          .to eql(refund.to_hash[:captures].first[:capture].deep_stringify_keys!.except('created_at'))
+      end
+    end
+
+    context 'when refund has failed' do
+      before do
+        allow(FlowcommerceSpree)
+          .to receive_message_chain(:client, :refunds, :post).and_raise(StandardError, 'Some error')
+      end
+
+      it 'returns an unsuccessful ActiveMerchant::Billing::Response and don`t add refund to order`s flow_data' do
+        allow(gateway).to receive(:add_refund_to_order).and_call_original
+        expect(gateway).not_to receive(:add_refund_to_order)
+
+        result = gateway.refund(payment, amount)
+
+        expect(result).to be_instance_of(ActiveMerchant::Billing::Response)
+        expect(result.message).to eql('Some error')
+        expect(result.success?).to eql(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adjusted Spree::Gateway::FlowIo.refund method to call client.refunds.post and return an ActiveMerchant::Billing::Response, either successful, or failed.

Adjusted error handling on the FlowcommerceSpree::LoggingHttpClient.
