### PR TITLE
[TEC-4958] Thank you page redirection order finalization.

### DIFF
--- a/app/services/flowcommerce_spree/order_updater.rb
+++ b/app/services/flowcommerce_spree/order_updater.rb
@@ -45,7 +45,7 @@ module FlowcommerceSpree
     def complete_checkout
       upsert_data
       map_payments_to_spree
-      finalize_order
+      finalize_order unless @order.complete?
     end
 
     def map_payments_to_spree

--- a/app/services/flowcommerce_spree/order_updater.rb
+++ b/app/services/flowcommerce_spree/order_updater.rb
@@ -45,7 +45,7 @@ module FlowcommerceSpree
     def complete_checkout
       upsert_data
       map_payments_to_spree
-      finalize_order unless @order.complete?
+      finalize_order if @order.state == 'complete'
     end
 
     def map_payments_to_spree

--- a/app/services/flowcommerce_spree/order_updater.rb
+++ b/app/services/flowcommerce_spree/order_updater.rb
@@ -45,6 +45,7 @@ module FlowcommerceSpree
     def complete_checkout
       upsert_data
       map_payments_to_spree
+      finalize_order
     end
 
     def map_payments_to_spree


### PR DESCRIPTION
### What problem is the code solving?
After completing the checkout on flow the user gets redirected to Spree thank you page. Before reaching the thank you page we have configured a proxy endpoint which pulls the order's information from flow updating at that moment and after that it redirects the user to the thank you page.

Unfortunately this proxy method is not properly closing the order so there are a couple of actions not being performed at that point like leaving the order "open", not triggering the stock allocation or sending the confirmation email.  

### How does this change address the problem?
By calling the `finalize_order` method which basically closes the order setting it as completed.

### Why is this the best solution?
Calling the `finalize_order` method before redirecting the user to the thank you page will help us with:
- setting the order's completed_at attribute which will tell the store to not show the order as open when the user navigates through it.
- reducing stock.
- triggering the order confirmation email.

The idea is to avoid waiting for the payment capture webhook to perform these actions since we are not sure how long those would take.

### Share the knowledge
We will still depend on the payment capture and fraud status update webhooks to properly "finalize" or "cancel' the order. Since the order will be left as completed but with payment "pending" until we receive either of those webhooks. If the order passes the fraud analysis, then the payment would be updated accordingly and the order would be ready to be exported on the next run. On the other hand if the order does not pass the fraud control then it would be canceled and a cancellation email would be triggered. 

