### PR TITLE
[TEC-4443] Adding flow_order? validation method that will help identifying if order is associated to flow.

### DIFF
--- a/app/models/spree/flow_io_order_decorator.rb
+++ b/app/models/spree/flow_io_order_decorator.rb
@@ -23,11 +23,10 @@ module Spree
       flow_data&.[]('order')
     end
 
-    def flow_order?
+    def flow_order_with_payments?
       payment = payments.completed.first
-      return payment.payment_method.type == 'Spree::Gateway::FlowIo' if payment
 
-      flow_data.present?
+      payment&.payment_method&.type == 'Spree::Gateway::FlowIo'
     end
 
     # accepts line item, usually called from views

--- a/app/models/spree/flow_io_order_decorator.rb
+++ b/app/models/spree/flow_io_order_decorator.rb
@@ -23,6 +23,13 @@ module Spree
       flow_data&.[]('order')
     end
 
+    def flow_order?
+      payment = payments.completed.first
+      return payment.payment_method.type == 'Spree::Gateway::FlowIo' if payment
+
+      flow_data.present?
+    end
+
     # accepts line item, usually called from views
     def flow_line_item_price(line_item, total = false)
       result = if (order = flow_order)

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -3,6 +3,41 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Order, type: :model do
+  describe '#flow_order?' do
+    context 'when order has flow_io data' do
+      let(:order) { create(:order, :with_flow_data) }
+
+      it 'returns true' do
+        expect(order.flow_order?).to(be_truthy)
+      end
+
+      context 'when payment is present' do
+        let(:gateway) { create(:flow_io_gateway) }
+        let!(:payment) { create(:payment, order: order, payment_method_id: gateway.id, state: 'completed') }
+
+        it 'returns true if payment is associated to Flow' do
+          expect(order.flow_order?).to(be_truthy)
+        end
+
+        context 'if payment is not associated to Flow' do
+          let(:gateway) { create(:flow_io_gateway, type: 'Spree::Gateway::Check') }
+
+          it 'returns false' do
+            expect(order.flow_order?).to(be_falsy)
+          end
+        end
+      end
+    end
+
+    context 'when order flow_data does not exists' do
+      let(:order) { create(:order) }
+
+      it 'returns false' do
+        expect(order.flow_order?).to(be_falsy)
+      end
+    end
+  end
+
   describe '#prepare_flow_addresses' do
     context 'when order flow_io data' do
       let(:order) { create(:order, :with_flow_data) }

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -3,37 +3,33 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Order, type: :model do
-  describe '#flow_order?' do
+  describe '#flow_order_with_payments?' do
     context 'when order has flow_io data' do
       let(:order) { create(:order, :with_flow_data) }
-
-      it 'returns true' do
-        expect(order.flow_order?).to(be_truthy)
-      end
 
       context 'when payment is present' do
         let(:gateway) { create(:flow_io_gateway) }
         let!(:payment) { create(:payment, order: order, payment_method_id: gateway.id, state: 'completed') }
 
         it 'returns true if payment is associated to Flow' do
-          expect(order.flow_order?).to(be_truthy)
+          expect(order.flow_order_with_payments?).to(be_truthy)
         end
 
         context 'if payment is not associated to Flow' do
           let(:gateway) { create(:flow_io_gateway, type: 'Spree::Gateway::Check') }
 
           it 'returns false' do
-            expect(order.flow_order?).to(be_falsy)
+            expect(order.flow_order_with_payments?).to(be_falsy)
           end
         end
       end
     end
 
-    context 'when order flow_data does not exists' do
+    context 'when payment is not present' do
       let(:order) { create(:order) }
 
       it 'returns false' do
-        expect(order.flow_order?).to(be_falsy)
+        expect(order.flow_order_with_payments?).to(be_falsy)
       end
     end
   end


### PR DESCRIPTION
### What problem is the code solving?
When exporting the order to Flow I was thinking of using a more accurate method to identify if the order is effectively associated to flow or not.

### How does this change address the problem?
Introducing a new `flow_order_with_payments?` method for the order. This methods checks first if there is a completed payment and then validates it's type. If the payment's type is effectively the same as Flow is using then it will return true; However if it is not then it will return false.

### Why is this the best solution?
I think it is worth testing the payment's data since we could remove the order's metadata by error. However the payment is a little more difficult to delete.