### PR TITLE
[DL-72] Adding some texts within Order's side bar and order's prices to link the user to Flow

### DIFF
--- a/app/overrides/spree/admin/order_sidebar_summary_flow_link.rb
+++ b/app/overrides/spree/admin/order_sidebar_summary_flow_link.rb
@@ -4,10 +4,10 @@ Deface::Override.new(
   insert_top: '.additional-info',
   text: '
     <% if FlowcommerceSpree::ORGANIZATION.present? && @order.flow_order.present? %>
-      <dt data-hook>Flow Order</dt>
-      <dd id="item_total">
-        <%= link_to "See order on Flow",
-                  "https://console.flow.io/#{FlowcommerceSpree::ORGANIZATION}/orders/#{@order.number}" %>
-      </dd>
+      <div style="text-align: center">
+        <%= link_to "See Flow Order",
+                    "https://console.flow.io/#{FlowcommerceSpree::ORGANIZATION}/orders/#{@order.number}",
+                    target: "_blank", class: "button" %>
+      </div>
     <% end %>'
 )

--- a/app/overrides/spree/admin/order_sidebar_summary_flow_link.rb
+++ b/app/overrides/spree/admin/order_sidebar_summary_flow_link.rb
@@ -1,0 +1,13 @@
+Deface::Override.new(
+  virtual_path: 'spree/admin/shared/_order_tabs',
+  name: 'spree_admin_order_additional_information_flow_message',
+  insert_top: '.additional-info',
+  text: '
+    <% if FlowcommerceSpree::ORGANIZATION.present? && @order.flow_order.present? %>
+      <dt data-hook>Flow Order</dt>
+      <dd id="item_total">
+        <%= link_to "See order on Flow",
+                  "https://console.flow.io/#{FlowcommerceSpree::ORGANIZATION}/orders/#{@order.number}" %>
+      </dd>
+    <% end %>'
+)

--- a/app/overrides/spree/admin/products/order_price_flow_message.rb
+++ b/app/overrides/spree/admin/products/order_price_flow_message.rb
@@ -1,0 +1,11 @@
+Deface::Override.new(
+  virtual_path: 'spree/admin/prices/index',
+  name: 'spree_admin_prices_flow_mesage',
+  insert_top: '.no-border-top',
+  text: "
+  <div style='margin-bottom: 20px;'>
+    <h5>
+      Some prices might not be shown in this list. You can find them here <a href='#{"https://console.flow.io/#{ENV['FLOW_ORGANIZATION']}/price-books"}'>here</a>.
+    </h5>
+  </div>"
+)

--- a/app/overrides/spree/admin/products/order_price_flow_message.rb
+++ b/app/overrides/spree/admin/products/order_price_flow_message.rb
@@ -4,6 +4,6 @@ Deface::Override.new(
   insert_top: '.no-border-top',
   text: "
   <div class='spree-admin-info' >
-    Some prices might not be shown in this list. You can find them <a href='#{"https://console.flow.io/#{ENV['FLOW_ORGANIZATION']}/price-books"}' target='_blank'>here</a>.
+    To check localized pricing, please click <a href='#{"https://console.flow.io/#{ENV['FLOW_ORGANIZATION']}/price-books"}' target='_blank'>here</a>.
   </div>"
 )

--- a/app/overrides/spree/admin/products/order_price_flow_message.rb
+++ b/app/overrides/spree/admin/products/order_price_flow_message.rb
@@ -3,9 +3,7 @@ Deface::Override.new(
   name: 'spree_admin_prices_flow_mesage',
   insert_top: '.no-border-top',
   text: "
-  <div style='margin-bottom: 20px;'>
-    <h5>
-      Some prices might not be shown in this list. You can find them here <a href='#{"https://console.flow.io/#{ENV['FLOW_ORGANIZATION']}/price-books"}' target='_blank'>here</a>.
-    </h5>
+  <div class='spree-admin-info' >
+    Some prices might not be shown in this list. You can find them <a href='#{"https://console.flow.io/#{ENV['FLOW_ORGANIZATION']}/price-books"}' target='_blank'>here</a>.
   </div>"
 )

--- a/app/overrides/spree/admin/products/order_price_flow_message.rb
+++ b/app/overrides/spree/admin/products/order_price_flow_message.rb
@@ -5,7 +5,7 @@ Deface::Override.new(
   text: "
   <div style='margin-bottom: 20px;'>
     <h5>
-      Some prices might not be shown in this list. You can find them here <a href='#{"https://console.flow.io/#{ENV['FLOW_ORGANIZATION']}/price-books"}'>here</a>.
+      Some prices might not be shown in this list. You can find them here <a href='#{"https://console.flow.io/#{ENV['FLOW_ORGANIZATION']}/price-books"}' target='_blank'>here</a>.
     </h5>
   </div>"
 )

--- a/lib/flowcommerce_spree/engine.rb
+++ b/lib/flowcommerce_spree/engine.rb
@@ -40,6 +40,9 @@ module FlowcommerceSpree
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')).sort.each do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
+      Dir.glob(File.join(File.dirname(__FILE__), '../app/overrides/*.rb')).sort.each do |c|
+        Rails.configuration.cache_classes ? require(c) : load(c)
+      end
     end
 
     config.to_prepare(&method(:activate).to_proc)


### PR DESCRIPTION
### What problem is the code solving?
Even though we have configured calculators, and gateways to make sure to update the order's date and create associated records to it based on the information pulled from Flow. The agent has no easy/quick way to identify if an order is associated to Flow.

Another issue we have is that the product's prices are handled within Flow using pricebooks for each experience and therefore that information is not available within the product's price book.

### How does this change address the problem?
By adding some overrides to add simple messages with links to the Flow's console.

### Why is this the best solution?
It would be the simplest solution while providing the administrator a quick vay of validating the information within flow if needed.

### Share the knowledge
**Order's edit page:**
![Screenshot from 2021-03-16 11-29-22](https://user-images.githubusercontent.com/1608166/111326095-089b5980-864b-11eb-8471-8a791fa701fd.png)

**Order's price list**
![Screenshot from 2021-03-26 14-32-52](https://user-images.githubusercontent.com/1608166/112858847-a69a1580-9088-11eb-9bac-c988e9ddb126.png)
