### PR TITLE
[NOTICKET] Removing code related to leftovers of default_request_ip_address Spree preference

### DIFF
--- a/app/controllers/concerns/current_zone_loader_decorator.rb
+++ b/app/controllers/concerns/current_zone_loader_decorator.rb
@@ -29,12 +29,7 @@ CurrentZoneLoader.module_eval do
                                        .where("meta -> 'flow_data' ->> 'country' = ?",
                                               ISO3166::Country[request_iso_code]&.alpha3).exists?
 
-    request_ip = if Rails.env.production?
-                   request.ip
-                 else
-                   Spree::Config[:debug_request_ip_address] || request.ip
-                   # Germany ip: 85.214.132.117, Sweden ip: 62.20.0.196, Moldova ip: 89.41.76.29
-                 end
+    request_ip = request.ip
 
     # This will issue a session creation request to flow.io. The response will contain the Flow Experience key and
     # the session_id

--- a/spec/dummy/app/models/spree/app_configuration_decorator.rb
+++ b/spec/dummy/app/models/spree/app_configuration_decorator.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Spree
-  AppConfiguration.class_eval do
-    preference :debug_request_ip_address, :string
-  end
-end


### PR DESCRIPTION
### What problem is the code solving?
The current_session is returning an error since it is trying to access the preference `debug_request_ip_address` which is no longer available.

### How does this change address the problem?
By removing leftover pieces of code.
