### PR TITLE
[DL-80] Capture_upserted_v2 webhook event handler specs and polishing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Metrics/AbcSize:
   Enabled: true
   Max: 25
   Exclude:
+    - 'spec/**/*'
 
 Metrics/BlockLength:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All flowcommerce_spree code is located in the ./app and ./lib folders.
 - Define these additional ENV variables. 
   - You will find FLOW_TOKEN, FLOW_ORGANIZATION and FLOW_BASE_COUNTRY in [Flow 
   console](https://console.flow.io/org_account_name/organization/integrations)
-  - To enable HTTP Basic authentication for securing the FlowcommerceSpree::WebhooksControler, prepend 
+  - To enable HTTP Basic authentication for securing the FlowcommerceSpree::WebhooksController, prepend 
     username:password@ to the hostname in your webhook URL. 
     By doing so, the credentials needed for authentication will be sent in the HTTP header.
     For example: https://username:password@www.mywebhookurl.com
@@ -141,11 +141,28 @@ by the following command:
 gem build flowcommerce_spree.gemspec
 ```
 
-Asuming the version was set to `0.0.1`, a `flowcommerce_spree-0.0.1.gem` will be generated at the root of the app 
-(repo).
+Assuming the version was set to `0.0.1`, 
+a `flowcommerce_spree-0.0.1.gem` binary file will be generated at the root of the app (repo).
+
+- The binary file shouldn't be added into the `git` tree, it will be pushed into the RubyGems and to the GitHub releases
 
 ### Pushing a new gem release to RubyGems
 
 ```
 gem push flowcommerce_spree-0.0.1.gem # don't forget to specify the correct version number
 ```
+
+### Crafting the new release on GitHub
+
+On the [Releases page](https://github.com/mejuri-inc/flowcommerce_spree/releases) push the `Draft a new release` button.
+
+The new release editing page opens, on which the following actions could be taken:
+
+- Choose the repo branch (default is `main`)
+- Insert a tag version (usually, the tag should correspond to the gem's new version, v0.0.1, for example)
+    - the tag will be created by GitHub on the last commit into the chosen branch
+- Fill the release Title and Description
+- Attach the binary file with the generated gem version
+- If the release is not yet ready for production, mark the `This is a pre-release` checkbox
+- Press either the `Publish release`, or the `Save draft button` if you want to publish it later
+    - After publishing the release, the the binary gem file will be available on GitHub and could be removed locally

--- a/app/models/spree/flow_io_order_decorator.rb
+++ b/app/models/spree/flow_io_order_decorator.rb
@@ -44,7 +44,7 @@ module Spree
 
     # shows localized total, if possible. if not, fall back to Spree default
     def flow_io_total_amount
-      flow_data&.dig('order', 'total', 'amount')&.to_d
+      flow_data&.dig('order', 'total', 'amount')&.to_d || 0
     end
 
     def flow_io_experience_key
@@ -88,13 +88,15 @@ module Spree
       flow_data&.[]('captures')&.each do |c|
         next if c['status'] != 'succeeded'
 
-        captures_sum += c['amount']
+        amount = c['amount']
+        amount = amount.to_d if amount.is_a?(String)
+        captures_sum += amount
       end
       captures_sum.to_d
     end
 
     def flow_io_balance_amount
-      flow_data&.dig('order', 'balance', 'amount')&.to_d
+      flow_data&.dig('order', 'balance', 'amount')&.to_d || 0
     end
 
     def flow_io_payments

--- a/app/services/flowcommerce_spree/webhooks/card_authorization_upserted_v2.rb
+++ b/app/services/flowcommerce_spree/webhooks/card_authorization_upserted_v2.rb
@@ -3,30 +3,29 @@
 module FlowcommerceSpree
   module Webhooks
     class CardAuthorizationUpsertedV2
-      attr_accessor :errors
+      attr_reader :errors
       alias full_messages errors
 
-      def self.process(data, opts = {})
-        new(data, opts).process
+      def self.process(data)
+        new(data).process
       end
 
-      def initialize(data, opts = {})
-        @card_auth = data['authorization']&.to_hash
-        @card_auth['method'].delete('images')
-        @opts = opts
+      def initialize(data)
+        @data = data['authorization']&.to_hash
+        @data&.[]('method')&.delete('images')
         @errors = []
       end
 
       def process
-        errors << { message: 'Authorization param missing' } && (return self) unless @card_auth
+        errors << { message: 'Authorization param missing' } && (return self) unless @data
 
-        errors << { message: 'Card param missing' } && (return self) unless (flow_io_card = @card_auth.delete('card'))
+        errors << { message: 'Card param missing' } && (return self) unless (flow_io_card = @data.delete('card'))
 
-        if (order_number = @card_auth.dig('order', 'number'))
+        if (order_number = @data.dig('order', 'number'))
           if (order = Spree::Order.find_by(number: order_number))
             card = upsert_card(flow_io_card, order)
 
-            order.payments.where(response_code: @card_auth['id'])
+            order.payments.where(response_code: @data['id'])
                  .update_all(source_id: card.id, source_type: 'Spree::CreditCard')
 
             return card
@@ -57,7 +56,7 @@ module FlowcommerceSpree
           card.imported = true
         end
 
-        card.push_authorization(@card_auth.except('discriminator'))
+        card.push_authorization(@data.except('discriminator'))
         card.new_record? ? card.save : card.update_column(:meta, card.meta.to_json)
 
         card

--- a/spec/factories/flow_io/card.rb
+++ b/spec/factories/flow_io/card.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flow_card, class: Io::Flow::V0::Models::Card do
+    id { Faker::Guid.guid }
+    token { Faker::Guid.guid }
+    type { 'visa' }
+    expiration { { month: (Time.now.utc + 1.year).month, year: (Time.now.utc + 1.year).year } }
+    iin { '4' }
+    issuer { { iin: '4' } }
+    last4 { '7036' }
+    name { "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/factories/flow_io/card_authorization.rb
+++ b/spec/factories/flow_io/card_authorization.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flow_card_authorization, class: Io::Flow::V0::Models::CardAuthorization do
+    id { Faker::Guid.guid }
+    key { id }
+    add_attribute(:method) { build(:flow_payment_method) }
+    order { { number: Faker::Guid.guid } }
+    card { build(:flow_card) }
+    amount { rand(0..100) }
+    currency { 'EUR' }
+    customer { build(:flow_order_customer) }
+    created_at { Time.now.utc }
+    attributes { {} }
+    result { { status: 'succeeded' } }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/factories/flow_io/payment_method.rb
+++ b/spec/factories/flow_io/payment_method.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flow_payment_method, class: Io::Flow::V0::Models::PaymentMethod do
+    id { Faker::Guid.guid }
+    type { 'card' }
+    name { 'VISA' }
+    images do
+      { small: { url: '', width: 10, height: 10 },
+        medium: { url: '', width: 10, height: 10 },
+        large: { url: '', width: 10, height: 10 } }
+    end
+    regions { [] }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/factories/spree/spree_payment_capture_events.rb
+++ b/spec/factories/spree/spree_payment_capture_events.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :payment_capture_event, class: Spree::PaymentCaptureEvent do
+    payment
+    amount { 100.00 }
+  end
+end

--- a/spec/services/flowcommerce_spree/order_sync_spec.rb
+++ b/spec/services/flowcommerce_spree/order_sync_spec.rb
@@ -176,8 +176,8 @@ RSpec.describe FlowcommerceSpree::OrderSync do
                   expect(instance).not_to receive(:add_customer_address)
                   expect(Io::Flow::V0::Models::OrderPutForm)
                     .to receive(:new)
-                          .with(items: [order_line_item], customer: customer_hash,
-                                attributes: nil, selections: nil, delivered_duty: nil)
+                    .with(items: [order_line_item], customer: customer_hash,
+                          attributes: nil, selections: nil, delivered_duty: nil)
 
                   expect(instance.synchronize!).to eql(checkout_token.id)
                   expect(order.flow_io_attributes['flow_return_url']).to eql(confirmation_url)

--- a/spec/services/flowcommerce_spree/webhooks/capture_upserted_v2_spec.rb
+++ b/spec/services/flowcommerce_spree/webhooks/capture_upserted_v2_spec.rb
@@ -1,0 +1,273 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FlowcommerceSpree::Webhooks::CaptureUpsertedV2 do
+  subject { FlowcommerceSpree::Webhooks::CaptureUpsertedV2 }
+
+  let(:gateway) { create(:flow_io_gateway) }
+  let(:order) { create(:order) }
+  let(:order_auth) { build(:flow_authorization_reference, order: { number: order.number }) }
+  let(:capture) { build(:flow_capture, authorization: order_auth) }
+  let(:data) { { 'capture' => Oj.load(capture.to_json) } }
+
+  before do
+    allow(subject).to receive(:new).and_call_original
+    allow(subject).to receive(:process).and_call_original
+  end
+
+  describe 'class methods' do
+    context '#process' do
+      it 'initializes the object instance with received data and calls `process` instance method on it' do
+        allow_any_instance_of(subject).to receive(:process)
+
+        expect(subject).to receive(:new).with(data)
+        expect_any_instance_of(subject).to receive(:process)
+
+        FlowcommerceSpree::Webhooks::CaptureUpsertedV2.process(data)
+      end
+    end
+  end
+
+  describe 'instance methods' do
+    let(:instance) { subject.new(data) }
+
+    describe '#initialize' do
+      it 'initializes the ivars, public `error` accessor and its `full_messages` alias' do
+        expect(instance.instance_variable_get(:@data)).to eql(data)
+        expect(instance.instance_variable_get(:@errors)).to eql([])
+        expect(instance.respond_to?(:errors)).to be_truthy
+        expect(instance.respond_to?(:full_messages)).to be_truthy
+
+        instance.instance_variable_set(:@errors, %w[error1 error2])
+
+        expect(instance.errors).to eql(%w[error1 error2])
+        expect(instance.full_messages).to eql(%w[error1 error2])
+      end
+    end
+
+    describe '#process' do
+      # let(:result) { instance.process }
+
+      context 'when @data contains no `capture` key' do
+        let(:instance) { subject.new(data.except('capture')) }
+
+        it 'returns self instance with errors' do
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CaptureUpsertedV2)
+          expect(result.errors).to eql([message: 'Capture param missing'])
+        end
+      end
+
+      context 'when @data[`capture`] contains no authorization' do
+        it 'returns self instance with errors' do
+          data['capture'].delete('authorization')
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CaptureUpsertedV2)
+          expect(result.errors).to eql([message: 'Order number param missing'])
+        end
+      end
+
+      context "when @data[`capture`]['authorization'] contains no order" do
+        it 'returns self instance with errors' do
+          data['capture']['authorization'].delete('order')
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CaptureUpsertedV2)
+          expect(result.errors).to eql([message: 'Order number param missing'])
+        end
+      end
+
+      context "when @data[`capture`]['authorization']['order'] contains no number" do
+        it 'returns self instance with errors' do
+          data['capture']['authorization']['order'].delete('number')
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CaptureUpsertedV2)
+          expect(result.errors).to eql([message: 'Order number param missing'])
+        end
+      end
+
+      context "when @data[`capture`]['authorization']['order']['number'] isn't found in the DB" do
+        it 'returns self instance with errors' do
+          data['capture']['authorization']['order']['number'] = "#{order.number}_"
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CaptureUpsertedV2)
+          expect(result.errors).to eql([message: "Order #{order.number}_ not found"])
+        end
+      end
+
+      context 'when capture authorization order number is found in the DB' do
+        let(:failed_capture) do
+          build(:flow_capture, id: capture.id, authorization: order_auth, status: 'failed')
+        end
+
+        before do
+          order.flow_data = { 'order' => { 'captures' => [failed_capture] } }
+          order.update_column(:meta, order.meta.to_json)
+
+          allow(FlowcommerceSpree::OrderUpdater).to receive(:new).and_call_original
+          allow_any_instance_of(FlowcommerceSpree::OrderUpdater).to receive(:finalize_order)
+          allow(instance).to receive(:upsert_order_captures).and_call_original
+          allow(instance).to receive(:map_payment_captures_to_spree).and_call_original
+          allow(instance).to receive(:captured_payment).and_call_original
+          allow_any_instance_of(Spree::Payment).to receive(:complete).and_call_original
+
+          expect(instance).to receive(:upsert_order_captures).with(order, data['capture'])
+        end
+
+        context 'and the order contains no flow_io payments' do
+          it 'returns the Spree::Order with upserted captures, not mapping captures to Spree' do
+            expect(instance).not_to receive(:map_payment_captures_to_spree)
+
+            result = instance.process
+
+            expect_order_with_capture(result, 'succeeded')
+          end
+        end
+
+        context 'and the order contains flow_io payments' do
+          let(:flow_payment) { build(:flow_order_payment, reference: order_auth.id) }
+          let(:zone) { create(:germany_zone, :with_flow_data) }
+
+          [Time.now.utc, nil].each do |timestamp|
+            context "and the order is #{timestamp ? 'completed' : 'not_completed'}" do
+              let(:order) { create(:order, zone: zone, completed_at: timestamp) }
+              let(:finalize) { timestamp ? false : true }
+
+              before do
+                order.flow_data['order']['payments'] = [flow_payment]
+                order.update_column(:meta, order.meta.to_json)
+
+                expect(instance).to receive(:map_payment_captures_to_spree)
+              end
+
+              context 'and received capture is successful' do
+                context 'and capture authorization matches flow_io payment authorization' do
+                  context 'and a Spree::Payment with received capture authorization exists' do
+                    let(:payment_amount) { capture.amount }
+                    let!(:payment) do
+                      create(:payment,
+                             payment_method_id: gateway.id, amount: payment_amount, response_code: order_auth.id)
+                    end
+
+                    context 'and no Spree::PaymentCaptureEvent exists for this payment' do
+                      before { Spree::PaymentCaptureEvent.destroy_all }
+
+                      context 'and payment state is not complete' do
+                        context 'and payment amount is not bigger than capture amount' do
+                          it 'creates PaymentCaptureEvent, completes payment, returns order with upserted captures' do
+                            expect(instance).to receive(:captured_payment)
+                            expect_any_instance_of(Spree::Payment).to receive(:complete)
+                            expect_order_finalize(order_finalize: finalize)
+
+                            result = nil
+                            expect { result = instance.process }
+                              .to change { Spree::PaymentCaptureEvent.count }.from(0).to(1)
+
+                            created_capture_event = Spree::PaymentCaptureEvent.first
+
+                            expect(created_capture_event.amount).to eql(capture.amount)
+                            expect(created_capture_event.flow_data['id']).to eql(capture.id)
+                            expect(payment.reload.state).to eql('completed')
+                            expect_order_with_capture(result, 'succeeded')
+                          end
+                        end
+
+                        context 'and payment amount is bigger than capture amount' do
+                          let(:payment_amount) { capture.amount + 1 }
+
+                          it 'creates a PaymentCaptureEvent, and returns order with upserted captures' do
+                            expect(instance).to receive(:captured_payment)
+                            expect_any_instance_of(Spree::Payment).not_to receive(:complete)
+                            expect(FlowcommerceSpree::OrderUpdater).not_to receive(:new)
+                            expect_any_instance_of(FlowcommerceSpree::OrderUpdater).not_to receive(:finalize_order)
+
+                            result = nil
+                            expect { result = instance.process }
+                              .to change { Spree::PaymentCaptureEvent.count }.from(0).to(1)
+
+                            created_capture_event = Spree::PaymentCaptureEvent.first
+
+                            expect(created_capture_event.amount).to eql(capture.amount)
+                            expect(created_capture_event.flow_data['id']).to eql(capture.id)
+                            expect(payment.reload.state).to eql('checkout')
+                            expect_order_with_capture(result, 'succeeded')
+                          end
+                        end
+                      end
+                    end
+
+                    context 'and a Spree::PaymentCaptureEvent for this payment already exists' do
+                      let!(:capture_event) do
+                        create(:payment_capture_event, payment_id: payment.id, flow_data: { id: capture.id })
+                      end
+
+                      it 'returns the Spree::Order with upserted captures, not creating a Spree::PaymentCaptureEvent' do
+                        result = expect_no_new_capture_events(order_finalize: finalize)
+                        expect_order_with_capture(result, 'succeeded')
+                      end
+                    end
+                  end
+
+                  context 'and no Spree::Payment with received capture authorization exists' do
+                    it 'returns the Spree::Order with upserted captures, not creating a Spree::PaymentCaptureEvent' do
+                      result = expect_no_new_capture_events(order_finalize: finalize)
+                      expect_order_with_capture(result, 'succeeded')
+                    end
+                  end
+                end
+
+                context 'and capture authorization does not match flow_io payment authorization' do
+                  let(:flow_payment) { build(:flow_order_payment, reference: 'wrong auth') }
+
+                  it 'returns the Spree::Order with upserted captures, not creating a Spree::PaymentCaptureEvent' do
+                    result = expect_no_new_capture_events(order_finalize: finalize)
+                    expect_order_with_capture(result, 'succeeded')
+                  end
+                end
+              end
+
+              context 'and received capture is not successful' do
+                let(:data) { { 'capture' => Oj.load(failed_capture.to_json) } }
+
+                it 'returns the Spree::Order with upserted captures' do
+                  result = expect_no_new_capture_events(order_finalize: finalize)
+                  expect_order_with_capture(result, 'failed')
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+def expect_no_new_capture_events(order_finalize: true)
+  expect(instance).to receive(:captured_payment).and_return(nil)
+  expect_order_finalize(order_finalize: order_finalize)
+
+  result = nil
+  expect { result = instance.process }.not_to(change { Spree::PaymentCaptureEvent.count })
+  result
+end
+
+def expect_order_finalize(order_finalize: true)
+  finalize = order_finalize ? :to : :not_to
+  expect(FlowcommerceSpree::OrderUpdater).__send__(finalize, receive(:new))
+  expect_any_instance_of(FlowcommerceSpree::OrderUpdater).__send__(finalize, receive(:finalize_order))
+end
+
+def expect_order_with_capture(result, capture_status)
+  expect(result).to be_a(Spree::Order)
+  expect(result.flow_data['captures']).to eql([data['capture']])
+  expect(result.flow_data['captures'].first['status']).to eql(capture_status)
+end

--- a/spec/services/flowcommerce_spree/webhooks/capture_upserted_v2_spec.rb
+++ b/spec/services/flowcommerce_spree/webhooks/capture_upserted_v2_spec.rb
@@ -47,8 +47,6 @@ RSpec.describe FlowcommerceSpree::Webhooks::CaptureUpsertedV2 do
     end
 
     describe '#process' do
-      # let(:result) { instance.process }
-
       context 'when @data contains no `capture` key' do
         let(:instance) { subject.new(data.except('capture')) }
 

--- a/spec/services/flowcommerce_spree/webhooks/card_authorization_upserted_v2_spec.rb
+++ b/spec/services/flowcommerce_spree/webhooks/card_authorization_upserted_v2_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2 do
+  subject { FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2 }
+
+  let(:gateway) { create(:flow_io_gateway) }
+  let(:user) { create(:user) }
+  let(:order1) { create(:order, user: user) }
+  let(:order2) { create(:order, user: user) }
+  let(:card1) { build(:flow_card) }
+  let(:card_auth1) { build(:flow_card_authorization, order: { number: order1.number }, card: card1) }
+  let(:card_auth2) { build(:flow_card_authorization, order: { number: order2.number }, card: card1) }
+  let(:data) { { 'authorization' => Oj.load(card_auth1.to_json), 'discriminator' => 'card_authorization_upserted_v2' } }
+
+  before do
+    allow(subject).to receive(:new).and_call_original
+    allow(subject).to receive(:process).and_call_original
+  end
+
+  describe 'class methods' do
+    context '#process' do
+      it 'initializes the object instance with received data and calls `process` instance method on it' do
+        allow_any_instance_of(subject).to receive(:process)
+
+        expect(subject).to receive(:new).with(data)
+        expect_any_instance_of(subject).to receive(:process)
+
+        FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2.process(data)
+      end
+    end
+  end
+
+  describe 'instance methods' do
+    let(:instance) { subject.new(data) }
+
+    describe '#initialize' do
+      it 'initializes the ivars, public `error` accessor and its `full_messages` alias' do
+        expect(instance.instance_variable_get(:@data)).to eql(data['authorization']&.to_hash)
+        expect(instance.instance_variable_get(:@errors)).to eql([])
+        expect(instance.respond_to?(:errors)).to be_truthy
+        expect(instance.respond_to?(:full_messages)).to be_truthy
+
+        instance.instance_variable_set(:@errors, %w[error1 error2])
+
+        expect(instance.errors).to eql(%w[error1 error2])
+        expect(instance.full_messages).to eql(%w[error1 error2])
+      end
+    end
+
+    describe '#process' do
+      context 'when data contains no `authorization` key' do
+        let(:instance) { subject.new(data.except('authorization')) }
+
+        it 'returns self instance with errors' do
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2)
+          expect(result.errors).to eql([message: 'Authorization param missing'])
+        end
+      end
+
+      context 'when data[`authorization`] contains no `card` key' do
+        it 'returns self instance with errors' do
+          data['authorization'].delete('card')
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2)
+          expect(result.errors).to eql([message: 'Card param missing'])
+        end
+      end
+
+      context "when data['authorization'] contains no order" do
+        it 'returns self instance with errors' do
+          data['authorization'].delete('order')
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2)
+          expect(result.errors).to eql([message: 'Order number param missing'])
+        end
+      end
+
+      context "when data['authorization']['order'] contains no number" do
+        it 'returns self instance with errors' do
+          data['authorization']['order'].delete('number')
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2)
+          expect(result.errors).to eql([message: 'Order number param missing'])
+        end
+      end
+
+      context "when data['authorization']['order']['number'] isn't found in the DB" do
+        it 'returns self instance with errors' do
+          data['authorization']['order']['number'] = "#{order1.number}_"
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2)
+          expect(result.errors).to eql([message: "Order #{order1.number}_ not found"])
+        end
+      end
+
+      context "when data['authorization']['order']['number'] is found in the DB" do
+        let!(:payment1) do
+          create(:payment, order: order1, response_code: card_auth1.id, payment_method: gateway)
+        end
+
+        before do
+          allow(instance).to receive(:upsert_card).and_call_original
+          allow_any_instance_of(Spree::CreditCard).to receive(:push_authorization).and_call_original
+
+          expect(instance).to receive(:upsert_card)
+        end
+
+        context 'and the credit card is not found in the DB' do
+          it 'creates and returns the new Spree::CreditCard, updating the payment source' do
+            expect_nil_payment_source(payment1)
+
+            result = nil
+
+            expect { result = instance.process }.to change { Spree::CreditCard.count }.from(0).to(1)
+            expect(result).to be_instance_of(Spree::CreditCard)
+
+            card = expect_card_attributes
+
+            card_auth_hash = Oj.load(card_auth1.to_json)
+
+            expect_card_attrs_in_flow_data(card, card_auth_hash)
+            expect(card.flow_data['authorizations'].first).to eql(card_auth_hash.except('discriminator'))
+
+            expect_payment_source_presence(payment1, card)
+          end
+        end
+
+        context 'and the credit card is found in the DB' do
+          let(:data2) do
+            { 'authorization' => Oj.load(card_auth2.to_json), 'discriminator' => 'card_authorization_upserted_v2' }
+          end
+          let!(:payment2) do
+            create(:payment, order: order2, response_code: card_auth2.id, payment_method: gateway)
+          end
+
+          it 'returns the found Spree::CreditCard with added authorization, updating the payment source' do
+            expect_nil_payment_source(payment1)
+
+            expect { instance.process }.to change { Spree::CreditCard.count }.from(0).to(1)
+
+            card = expect_card_attributes
+
+            expect_payment_source_presence(payment1, card)
+
+            expect_nil_payment_source(payment2)
+
+            result = nil
+            expect { result = subject.new(data2).process }.not_to(change { Spree::CreditCard.count })
+            expect(result).to be_instance_of(Spree::CreditCard)
+
+            card.reload
+
+            card_auth_hash = Oj.load(card_auth2.to_json)
+            expect_card_attrs_in_flow_data(card, card_auth_hash)
+
+            card_authorizations = card.flow_data['authorizations']
+
+            expect(card_authorizations).to be_instance_of(Array)
+            expect(card_authorizations.size).to eql(2)
+            expect(card_authorizations.last).to eql(card_auth_hash.except('discriminator'))
+
+            expect_payment_source_presence(payment2, card)
+          end
+        end
+      end
+    end
+  end
+end
+
+def expect_nil_payment_source(payment)
+  expect(payment.source_id).to be_nil
+  expect(payment.source_type).to be_nil
+end
+
+def expect_payment_source_presence(payment, card)
+  payment.reload
+  expect(payment.source_id).to eql(card.id)
+  expect(payment.source_type).to eql('Spree::CreditCard')
+end
+
+def expect_card_attributes
+  card = Spree::CreditCard.first
+
+  expect(card.month).to eql(card1.expiration.month.to_s)
+  expect(card.year).to eql(card1.expiration.year.to_s)
+  expect(card.cc_type).to eql(card1.type.value)
+  expect(card.last_digits).to eql(card1.last4)
+  expect(card.name).to eql(card1.name)
+  expect(card.user_id).to eql(user.id)
+
+  card
+end
+
+def expect_card_attrs_in_flow_data(card, card_auth_hash)
+  card_auth_hash['method'].delete('images')
+  card_hash = card_auth_hash.delete('card')
+
+  expect(card.flow_data.except('authorizations'))
+    .to eql(card_hash.except('discriminator', 'expiration', 'type', 'last4', 'name'))
+end


### PR DESCRIPTION
Spree::Order.flow_io_total_amount and `flow_io_balance_amount` methods now are returning 0 when amount is `nil`

Spree::Order.flow_io_experience_key is converting amount.to_d if it is a String

CaptureUpsertedV2 changes:

- errors accessor is now only `reader`
- only one param is received - `data` (no more `opts` hash)
- added order number param presence validation in `data`
- for simplification, separated some code from `process` method into the `upsert_order_captures` method
