### PR TITLE
[DL-80] CardAuthorizationUpsertedV2 specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Metrics/AbcSize:
   Enabled: true
   Max: 25
   Exclude:
+    - 'spec/**/*'
 
 Metrics/BlockLength:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All flowcommerce_spree code is located in the ./app and ./lib folders.
 - Define these additional ENV variables. 
   - You will find FLOW_TOKEN, FLOW_ORGANIZATION and FLOW_BASE_COUNTRY in [Flow 
   console](https://console.flow.io/org_account_name/organization/integrations)
-  - To enable HTTP Basic authentication for securing the FlowcommerceSpree::WebhooksControler, prepend 
+  - To enable HTTP Basic authentication for securing the FlowcommerceSpree::WebhooksController, prepend 
     username:password@ to the hostname in your webhook URL. 
     By doing so, the credentials needed for authentication will be sent in the HTTP header.
     For example: https://username:password@www.mywebhookurl.com
@@ -141,11 +141,28 @@ by the following command:
 gem build flowcommerce_spree.gemspec
 ```
 
-Asuming the version was set to `0.0.1`, a `flowcommerce_spree-0.0.1.gem` will be generated at the root of the app 
-(repo).
+Assuming the version was set to `0.0.1`, 
+a `flowcommerce_spree-0.0.1.gem` binary file will be generated at the root of the app (repo).
+
+- The binary file shouldn't be added into the `git` tree, it will be pushed into the RubyGems and to the GitHub releases
 
 ### Pushing a new gem release to RubyGems
 
 ```
 gem push flowcommerce_spree-0.0.1.gem # don't forget to specify the correct version number
 ```
+
+### Crafting the new release on GitHub
+
+On the [Releases page](https://github.com/mejuri-inc/flowcommerce_spree/releases) push the `Draft a new release` button.
+
+The new release editing page opens, on which the following actions could be taken:
+
+- Choose the repo branch (default is `main`)
+- Insert a tag version (usually, the tag should correspond to the gem's new version, v0.0.1, for example)
+    - the tag will be created by GitHub on the last commit into the chosen branch
+- Fill the release Title and Description
+- Attach the binary file with the generated gem version
+- If the release is not yet ready for production, mark the `This is a pre-release` checkbox
+- Press either the `Publish release`, or the `Save draft button` if you want to publish it later
+    - After publishing the release, the the binary gem file will be available on GitHub and could be removed locally

--- a/app/services/flowcommerce_spree/webhooks/card_authorization_upserted_v2.rb
+++ b/app/services/flowcommerce_spree/webhooks/card_authorization_upserted_v2.rb
@@ -3,30 +3,29 @@
 module FlowcommerceSpree
   module Webhooks
     class CardAuthorizationUpsertedV2
-      attr_accessor :errors
+      attr_reader :errors
       alias full_messages errors
 
-      def self.process(data, opts = {})
-        new(data, opts).process
+      def self.process(data)
+        new(data).process
       end
 
-      def initialize(data, opts = {})
-        @card_auth = data['authorization']&.to_hash
-        @card_auth['method'].delete('images')
-        @opts = opts
+      def initialize(data)
+        @data = data['authorization']&.to_hash
+        @data&.[]('method')&.delete('images')
         @errors = []
       end
 
       def process
-        errors << { message: 'Authorization param missing' } && (return self) unless @card_auth
+        errors << { message: 'Authorization param missing' } && (return self) unless @data
 
-        errors << { message: 'Card param missing' } && (return self) unless (flow_io_card = @card_auth.delete('card'))
+        errors << { message: 'Card param missing' } && (return self) unless (flow_io_card = @data.delete('card'))
 
-        if (order_number = @card_auth.dig('order', 'number'))
+        if (order_number = @data.dig('order', 'number'))
           if (order = Spree::Order.find_by(number: order_number))
             card = upsert_card(flow_io_card, order)
 
-            order.payments.where(response_code: @card_auth['id'])
+            order.payments.where(response_code: @data['id'])
                  .update_all(source_id: card.id, source_type: 'Spree::CreditCard')
 
             return card
@@ -57,7 +56,7 @@ module FlowcommerceSpree
           card.imported = true
         end
 
-        card.push_authorization(@card_auth.except('discriminator'))
+        card.push_authorization(@data.except('discriminator'))
         card.new_record? ? card.save : card.update_column(:meta, card.meta.to_json)
 
         card

--- a/spec/factories/flow_io/card.rb
+++ b/spec/factories/flow_io/card.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flow_card, class: Io::Flow::V0::Models::Card do
+    id { Faker::Guid.guid }
+    token { Faker::Guid.guid }
+    type { 'visa' }
+    expiration { { month: (Time.now.utc + 1.year).month, year: (Time.now.utc + 1.year).year } }
+    iin { '4' }
+    issuer { { iin: '4' } }
+    last4 { '7036' }
+    name { "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/factories/flow_io/card_authorization.rb
+++ b/spec/factories/flow_io/card_authorization.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flow_card_authorization, class: Io::Flow::V0::Models::CardAuthorization do
+    id { Faker::Guid.guid }
+    key { id }
+    add_attribute(:method) { build(:flow_payment_method) }
+    order { { number: Faker::Guid.guid } }
+    card { build(:flow_card) }
+    amount { rand(0..100) }
+    currency { 'EUR' }
+    customer { build(:flow_order_customer) }
+    created_at { Time.now.utc }
+    attributes { {} }
+    result { { status: 'succeeded' } }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/factories/flow_io/payment_method.rb
+++ b/spec/factories/flow_io/payment_method.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flow_payment_method, class: Io::Flow::V0::Models::PaymentMethod do
+    id { Faker::Guid.guid }
+    type { 'card' }
+    name { 'VISA' }
+    images do
+      { small: { url: '', width: 10, height: 10 },
+        medium: { url: '', width: 10, height: 10 },
+        large: { url: '', width: 10, height: 10 } }
+    end
+    regions { [] }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/services/flowcommerce_spree/webhooks/capture_upserted_v2_spec.rb
+++ b/spec/services/flowcommerce_spree/webhooks/capture_upserted_v2_spec.rb
@@ -47,8 +47,6 @@ RSpec.describe FlowcommerceSpree::Webhooks::CaptureUpsertedV2 do
     end
 
     describe '#process' do
-      # let(:result) { instance.process }
-
       context 'when @data contains no `capture` key' do
         let(:instance) { subject.new(data.except('capture')) }
 

--- a/spec/services/flowcommerce_spree/webhooks/card_authorization_upserted_v2_spec.rb
+++ b/spec/services/flowcommerce_spree/webhooks/card_authorization_upserted_v2_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2 do
+  subject { FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2 }
+
+  let(:gateway) { create(:flow_io_gateway) }
+  let(:user) { create(:user) }
+  let(:order) { create(:order, user: user) }
+  let(:card_auth) { build(:flow_card_authorization, order: { number: order.number }) }
+  let(:data) { { 'authorization' => Oj.load(card_auth.to_json), 'discriminator' => 'card_authorization_upserted_v2' } }
+
+  before do
+    allow(subject).to receive(:new).and_call_original
+    allow(subject).to receive(:process).and_call_original
+  end
+
+  describe 'class methods' do
+    context '#process' do
+      it 'initializes the object instance with received data and calls `process` instance method on it' do
+        allow_any_instance_of(subject).to receive(:process)
+
+        expect(subject).to receive(:new).with(data)
+        expect_any_instance_of(subject).to receive(:process)
+
+        FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2.process(data)
+      end
+    end
+  end
+
+  describe 'instance methods' do
+    let(:instance) { subject.new(data) }
+
+    describe '#initialize' do
+      it 'initializes the ivars, public `error` accessor and its `full_messages` alias' do
+        expect(instance.instance_variable_get(:@data)).to eql(data['authorization']&.to_hash)
+        expect(instance.instance_variable_get(:@errors)).to eql([])
+        expect(instance.respond_to?(:errors)).to be_truthy
+        expect(instance.respond_to?(:full_messages)).to be_truthy
+
+        instance.instance_variable_set(:@errors, %w[error1 error2])
+
+        expect(instance.errors).to eql(%w[error1 error2])
+        expect(instance.full_messages).to eql(%w[error1 error2])
+      end
+    end
+
+    describe '#process' do
+      context 'when data contains no `authorization` key' do
+        let(:instance) { subject.new(data.except('authorization')) }
+
+        it 'returns self instance with errors' do
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2)
+          expect(result.errors).to eql([message: 'Authorization param missing'])
+        end
+      end
+
+      context 'when data[`authorization`] contains no `card` key' do
+        it 'returns self instance with errors' do
+          data['authorization'].delete('card')
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2)
+          expect(result.errors).to eql([message: 'Card param missing'])
+        end
+      end
+
+      context "when data['authorization'] contains no order" do
+        it 'returns self instance with errors' do
+          data['authorization'].delete('order')
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2)
+          expect(result.errors).to eql([message: 'Order number param missing'])
+        end
+      end
+
+      context "when data['authorization']['order'] contains no number" do
+        it 'returns self instance with errors' do
+          data['authorization']['order'].delete('number')
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2)
+          expect(result.errors).to eql([message: 'Order number param missing'])
+        end
+      end
+
+      context "when data['authorization']['order']['number'] isn't found in the DB" do
+        it 'returns self instance with errors' do
+          data['authorization']['order']['number'] = "#{order.number}_"
+
+          result = instance.process
+
+          expect(result).to be_a(FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2)
+          expect(result.errors).to eql([message: "Order #{order.number}_ not found"])
+        end
+      end
+
+      context "when data['authorization']['order']['number'] is found in the DB" do
+        before do
+          allow(instance).to receive(:upsert_card).and_call_original
+          allow_any_instance_of(Spree::CreditCard).to receive(:push_authorization).and_call_original
+
+          expect(instance).to receive(:upsert_card)
+        end
+
+        context 'and the credit card is not found in the DB' do
+          it 'returns the new Spree::CreditCard with upserted captures, not mapping captures to Spree' do
+            result = nil
+
+            expect { result = instance.process }.to change { Spree::CreditCard.count }.from(0).to(1)
+            expect(result).to be_instance_of(Spree::CreditCard)
+
+            card = Spree::CreditCard.first
+
+            expect(card.month).to eql(card_auth.card.expiration.month.to_s)
+            expect(card.year).to eql(card_auth.card.expiration.year.to_s)
+            expect(card.cc_type).to eql(card_auth.card.type.value)
+            expect(card.last_digits).to eql(card_auth.card.last4)
+            expect(card.name).to eql(card_auth.card.name)
+            expect(card.user_id).to eql(user.id)
+
+            card_auth_hash = Oj.load(card_auth.to_json)
+            card_hash = card_auth_hash.delete('card')
+            expect(card.flow_data.except('authorizations'))
+              .to eql(card_hash.except('discriminator', 'expiration', 'type', 'last4', 'name'))
+
+            card_auth_hash['method'].delete('images')
+            expect(card.flow_data['authorizations'].first).to eql(card_auth_hash.except('discriminator'))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/flowcommerce_spree/webhooks/card_authorization_upserted_v2_spec.rb
+++ b/spec/services/flowcommerce_spree/webhooks/card_authorization_upserted_v2_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2 do
 
   let(:gateway) { create(:flow_io_gateway) }
   let(:user) { create(:user) }
-  let(:order) { create(:order, user: user) }
-  let(:card_auth) { build(:flow_card_authorization, order: { number: order.number }) }
-  let(:data) { { 'authorization' => Oj.load(card_auth.to_json), 'discriminator' => 'card_authorization_upserted_v2' } }
+  let(:order1) { create(:order, user: user) }
+  let(:order2) { create(:order, user: user) }
+  let(:card1) { build(:flow_card) }
+  let(:card_auth1) { build(:flow_card_authorization, order: { number: order1.number }, card: card1) }
+  let(:card_auth2) { build(:flow_card_authorization, order: { number: order2.number }, card: card1) }
+  let(:data) { { 'authorization' => Oj.load(card_auth1.to_json), 'discriminator' => 'card_authorization_upserted_v2' } }
 
   before do
     allow(subject).to receive(:new).and_call_original
@@ -93,16 +96,20 @@ RSpec.describe FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2 do
 
       context "when data['authorization']['order']['number'] isn't found in the DB" do
         it 'returns self instance with errors' do
-          data['authorization']['order']['number'] = "#{order.number}_"
+          data['authorization']['order']['number'] = "#{order1.number}_"
 
           result = instance.process
 
           expect(result).to be_a(FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2)
-          expect(result.errors).to eql([message: "Order #{order.number}_ not found"])
+          expect(result.errors).to eql([message: "Order #{order1.number}_ not found"])
         end
       end
 
       context "when data['authorization']['order']['number'] is found in the DB" do
+        let!(:payment1) do
+          create(:payment, order: order1, response_code: card_auth1.id, payment_method: gateway)
+        end
+
         before do
           allow(instance).to receive(:upsert_card).and_call_original
           allow_any_instance_of(Spree::CreditCard).to receive(:push_authorization).and_call_original
@@ -111,31 +118,95 @@ RSpec.describe FlowcommerceSpree::Webhooks::CardAuthorizationUpsertedV2 do
         end
 
         context 'and the credit card is not found in the DB' do
-          it 'returns the new Spree::CreditCard with upserted captures, not mapping captures to Spree' do
+          it 'creates and returns the new Spree::CreditCard, updating the payment source' do
+            expect_nil_payment_source(payment1)
+
             result = nil
 
             expect { result = instance.process }.to change { Spree::CreditCard.count }.from(0).to(1)
             expect(result).to be_instance_of(Spree::CreditCard)
 
-            card = Spree::CreditCard.first
+            card = expect_card_attributes
 
-            expect(card.month).to eql(card_auth.card.expiration.month.to_s)
-            expect(card.year).to eql(card_auth.card.expiration.year.to_s)
-            expect(card.cc_type).to eql(card_auth.card.type.value)
-            expect(card.last_digits).to eql(card_auth.card.last4)
-            expect(card.name).to eql(card_auth.card.name)
-            expect(card.user_id).to eql(user.id)
+            card_auth_hash = Oj.load(card_auth1.to_json)
 
-            card_auth_hash = Oj.load(card_auth.to_json)
-            card_hash = card_auth_hash.delete('card')
-            expect(card.flow_data.except('authorizations'))
-              .to eql(card_hash.except('discriminator', 'expiration', 'type', 'last4', 'name'))
-
-            card_auth_hash['method'].delete('images')
+            expect_card_attrs_in_flow_data(card, card_auth_hash)
             expect(card.flow_data['authorizations'].first).to eql(card_auth_hash.except('discriminator'))
+
+            expect_payment_source_presence(payment1, card)
+          end
+        end
+
+        context 'and the credit card is found in the DB' do
+          let(:data2) do
+            { 'authorization' => Oj.load(card_auth2.to_json), 'discriminator' => 'card_authorization_upserted_v2' }
+          end
+          let!(:payment2) do
+            create(:payment, order: order2, response_code: card_auth2.id, payment_method: gateway)
+          end
+
+          it 'returns the found Spree::CreditCard with added authorization, updating the payment source' do
+            expect_nil_payment_source(payment1)
+
+            expect { instance.process }.to change { Spree::CreditCard.count }.from(0).to(1)
+
+            card = expect_card_attributes
+
+            expect_payment_source_presence(payment1, card)
+
+            expect_nil_payment_source(payment2)
+
+            result = nil
+            expect { result = subject.new(data2).process }.not_to(change { Spree::CreditCard.count })
+            expect(result).to be_instance_of(Spree::CreditCard)
+
+            card.reload
+
+            card_auth_hash = Oj.load(card_auth2.to_json)
+            expect_card_attrs_in_flow_data(card, card_auth_hash)
+
+            card_authorizations = card.flow_data['authorizations']
+
+            expect(card_authorizations).to be_instance_of(Array)
+            expect(card_authorizations.size).to eql(2)
+            expect(card_authorizations.last).to eql(card_auth_hash.except('discriminator'))
+
+            expect_payment_source_presence(payment2, card)
           end
         end
       end
     end
   end
+end
+
+def expect_nil_payment_source(payment)
+  expect(payment.source_id).to be_nil
+  expect(payment.source_type).to be_nil
+end
+
+def expect_payment_source_presence(payment, card)
+  payment.reload
+  expect(payment.source_id).to eql(card.id)
+  expect(payment.source_type).to eql('Spree::CreditCard')
+end
+
+def expect_card_attributes
+  card = Spree::CreditCard.first
+
+  expect(card.month).to eql(card1.expiration.month.to_s)
+  expect(card.year).to eql(card1.expiration.year.to_s)
+  expect(card.cc_type).to eql(card1.type.value)
+  expect(card.last_digits).to eql(card1.last4)
+  expect(card.name).to eql(card1.name)
+  expect(card.user_id).to eql(user.id)
+
+  card
+end
+
+def expect_card_attrs_in_flow_data(card, card_auth_hash)
+  card_auth_hash['method'].delete('images')
+  card_hash = card_auth_hash.delete('card')
+
+  expect(card.flow_data.except('authorizations'))
+    .to eql(card_hash.except('discriminator', 'expiration', 'type', 'last4', 'name'))
 end


### PR DESCRIPTION
CardAuthorizationUpsertedV2 changes:
- errors accessor is now only reader
- only one param is received - data (no more opts hash)
- changed `@card_auth` to `@data` for consistency with other webhook handlers

Added `FlowIo` card, card_authorization and payment_method factories.

