### PR TITLE
[DL-276] Adding charge_default and lower_boundary to the shipping FlowIo calculator

### DIFF
--- a/app/models/spree/calculator/shipping/flow_io.rb
+++ b/app/models/spree/calculator/shipping/flow_io.rb
@@ -4,6 +4,9 @@ module Spree
   class Calculator
     module Shipping
       class FlowIo < ShippingCalculator
+        preference :lower_boundary, :decimal, default: 100
+        preference :charge_default, :decimal, default: 15
+
         def self.description
           'FlowIO Calculator'
         end
@@ -16,11 +19,11 @@ module Spree
         end
 
         def default_charge(_country)
-          0
+          preferred_charge_default
         end
 
         def threshold
-          0
+          preferred_lower_boundary
         end
 
         private


### PR DESCRIPTION
### What problem is the code solving?
Flow Orders are currently showing a wrong Shipping Estimated and Free shipping threshold within the Cart. We need a way to configure these values for flow orders.

### How does this change address the problem?
By adding preferences **lower_boundary** and **charge_default** to the Shipping::Calculator::FlowIo.

### Why is this the best solution?
The best solution would be to obtain these those values from Flow. However doing so will probably require more code changes which due to times we are going to handle in the near future in in a new ticket.

### Share the knowledge
This configuration will only work for Spree side. If we want those values to also apply to the checkout we have to replicate them in Flow's configuration. 
