### PR TITLE
[DL-67] Small change on current_zone_loader module to only load active zones for Flow

### DIFF
--- a/app/controllers/concerns/current_zone_loader_decorator.rb
+++ b/app/controllers/concerns/current_zone_loader_decorator.rb
@@ -7,11 +7,13 @@ CurrentZoneLoader.module_eval do
     return @current_zone if defined?(@current_zone)
 
     @current_zone = if (session_region_name = session['region']&.[]('name'))
-                      Spree::Zones::Product.find_by(name: session_region_name)
-                    elsif request_iso_code.present?
-                      @current_zone = flow_zone
-                      @current_zone ||= Spree::Country.find_by(iso: request_iso_code)&.product_zones&.active&.first
+                      Spree::Zones::Product.find_by(name: session_region_name, status: 'active')
                     end
+
+    @current_zone ||= if request_iso_code.present?
+                        @current_zone = flow_zone
+                        @current_zone ||= Spree::Country.find_by(iso: request_iso_code)&.product_zones&.active&.first
+                      end
 
     @current_zone ||= Spree::Zones::Product.find_by(name: 'International') ||
                       Spree::Zones::Product.new(name: 'International', taxon_ids: [], currencies: %w[USD CAD])

--- a/app/controllers/flowcommerce_spree/orders_controller.rb
+++ b/app/controllers/flowcommerce_spree/orders_controller.rb
@@ -9,7 +9,9 @@ module FlowcommerceSpree
     # proxy enpoint between flow and thankyou page.
     # /flow/order_completed endpoint
     def order_completed
-      flow_updater = FlowcommerceSpree::OrderUpdater.new(order: current_order)
+      order = Spree::Order.find_by number: params[:order], guest_token: params[:t]
+
+      flow_updater = FlowcommerceSpree::OrderUpdater.new(order: order)
       flow_updater.complete_checkout
 
       redirect_to "/thankyou?order=#{params[:order]}&t=#{params[:t]}"

--- a/app/models/spree/zones/flow_io_product_zone_decorator.rb
+++ b/app/models/spree/zones/flow_io_product_zone_decorator.rb
@@ -28,6 +28,10 @@ module Spree
         flow_data&.[]('key').present? && flow_data['status'] == 'active'
       end
 
+      def flow_io_active_or_archiving_experience?
+        flow_data&.[]('key').present? && %w[active archiving].include?(flow_data['status'])
+      end
+
       def update_on_flow; end
 
       def remove_on_flow_io

--- a/app/services/flowcommerce_spree/order_updater.rb
+++ b/app/services/flowcommerce_spree/order_updater.rb
@@ -3,7 +3,9 @@
 module FlowcommerceSpree
   class OrderUpdater
     def initialize(order:)
-      raise(ArgumentError, 'Experience not defined or not active') unless order&.zone&.flow_io_active_or_archiving_experience?
+      unless order&.zone&.flow_io_active_or_archiving_experience?
+        raise(ArgumentError, 'Experience not defined or not active')
+      end
 
       @experience = order.flow_io_experience_key
       @order = order

--- a/app/services/flowcommerce_spree/order_updater.rb
+++ b/app/services/flowcommerce_spree/order_updater.rb
@@ -3,7 +3,7 @@
 module FlowcommerceSpree
   class OrderUpdater
     def initialize(order:)
-      raise(ArgumentError, 'Experience not defined or not active') unless order&.zone&.flow_io_active_experience?
+      raise(ArgumentError, 'Experience not defined or not active') unless order&.zone&.flow_io_active_or_archiving_experience?
 
       @experience = order.flow_io_experience_key
       @order = order


### PR DESCRIPTION
### What problem is the code solving?
When Flow experience is archived, Spree will still keep loading the experience from the session which will eventually start raising errors since Flow will not allow new sessions to be requested. 

### How does this change address the problem?
By doing a couple of changes to avoid loading experiences that are not active.

- CurrentZoneLoader#current_zone method will check for the zone's status when loading the zone using the session's stored name. This way if the zone is archived it will try loading a new zone.
- OrderUpdater#complete_order: to accept requests even when the zone's status is in archiving status.

### Why is this the best solution?
By restricting the current_zone to only use "active" zones we make sure that the experience for users that are not in the checkout will stay updated based on the zone's status. Flow is currently not blocking nor raising an error during the checkout if the experience is not active, instead they will block the creation of new sessions. This means that users will be able to complete the checkout and therefore Spree needs a way to properly update the order once the flow checkout is completed instead of raising an error due to the experience not being active.
