### PR TITLE
[NO-TICKET] Changing Session creation strategy to use country ISO code instead of request IP

### DIFF
--- a/app/controllers/concerns/current_zone_loader_decorator.rb
+++ b/app/controllers/concerns/current_zone_loader_decorator.rb
@@ -31,16 +31,9 @@ CurrentZoneLoader.module_eval do
                                        .where("meta -> 'flow_data' ->> 'country' = ?",
                                               ISO3166::Country[request_iso_code]&.alpha3).exists?
 
-    request_ip = if Rails.env.production?
-                   request.ip
-                 else
-                   Spree::Config[:debug_request_ip_address] || request.ip
-                   # Germany ip: 85.214.132.117, Sweden ip: 62.20.0.196, Moldova ip: 89.41.76.29
-                 end
-
     # This will issue a session creation request to flow.io. The response will contain the Flow Experience key and
     # the session_id
-    flow_io_session = FlowcommerceSpree::Session.create(ip: request_ip, visitor: visitor_id_for_flow_io)
+    flow_io_session = FlowcommerceSpree::Session.create(country: request_iso_code, visitor: visitor_id_for_flow_io)
 
     if (zone = Spree::Zones::Product.active.find_by(name: flow_io_session.experience&.key&.titleize))
       session['flow_session_id'] = flow_io_session.id

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Spree
-  AppConfiguration.class_eval do
-    preference :debug_request_ip_address, :string
-  end
-end

--- a/lib/flowcommerce_spree/session.rb
+++ b/lib/flowcommerce_spree/session.rb
@@ -5,16 +5,14 @@ module FlowcommerceSpree
   class Session
     attr_accessor :session, :localized, :visitor
 
-    def self.create(ip:, visitor:, experience: nil)
-      instance = new(ip: ip, visitor: visitor, experience: experience)
+    def self.create(country:, visitor:, experience: nil)
+      instance = new(country: country, visitor: visitor, experience: experience)
       instance.create
       instance
     end
 
-    def initialize(ip:, visitor:, experience: nil)
-      ip = '127.0.0.1' if ip == '::1'
-
-      @ip      = ip
+    def initialize(country:, visitor:, experience: nil)
+      @country = country
       @visitor = visitor
       @experience = experience
     end
@@ -22,7 +20,7 @@ module FlowcommerceSpree
     # create session without or with experience (the latter is useful for creating a new session with the order's
     # experience on refreshing the checkout_token)
     def create
-      data = { ip: @ip,
+      data = { country: @country,
                visit: { id: @visitor,
                         expires_at: (Time.now + 30.minutes).iso8601 } }
       data[:experience] = @experience if @experience


### PR DESCRIPTION
### What problem is the code solving?
The Geolocalization by IP is not working properly on all scenarios.

### How does this change address the problem?
Changing session creation strategy  based on IP to country.

### Why is this the best solution?
The behavior within the rest of the application is handled based on country. Changing this strategy to country should not bother us. In the future we can also support using IP in case we want to.