### PR TITLE
[DL-499] Adding new credit method to FlowIo Gateway.

### DIFF
--- a/app/models/spree/gateway/flow_io.rb
+++ b/app/models/spree/gateway/flow_io.rb
@@ -117,8 +117,7 @@ module Spree
                                          response_code: response.authorization,
                                          payment_method_id: original_payment&.payment_method_id,
                                          amount: - response.params['amount'].to_f,
-                                         source_id: original_payment&.source_id,
-                                         source_type: original_payment&.source_type)
+                                         source: original_payment)
 
         # For now this additional update is overwriting the generated identifier with flow.io payment identifier.
         # TODO: Check and possibly refactor in Spree 3.0, where the `before_create :set_unique_identifier`

--- a/spec/models/spree/gateway/flow_io_spec.rb
+++ b/spec/models/spree/gateway/flow_io_spec.rb
@@ -11,6 +11,38 @@ RSpec.describe Spree::Gateway::FlowIo do
     end
   end
 
+  shared_examples 'successful refund' do
+    it 'returns a successful response' do
+      expect(@result).to be_instance_of(ActiveMerchant::Billing::Response)
+      expect(@result.message).to eql(Spree::Gateway::FlowIo::REFUND_SUCCESS)
+      expect(@result.success?).to eql(true)
+    end
+
+    it 'stores refund`s data within flow_data' do
+      order.reload
+      order_refunds = order.flow_data['refunds']
+      expect(order_refunds).to be_instance_of(Array)
+
+      order_refund = order_refunds.first
+      order_refund_captures = order_refund.delete('captures')
+      expect(order_refund_captures).to be_instance_of(Array)
+
+      refund_capture = order_refund_captures.first['capture']
+      expect(order_refund.except('created_at'))
+        .to eql(refund.to_hash.except(:captures, :created_at).deep_stringify_keys!)
+      expect(refund_capture.except('created_at'))
+        .to eql(refund.to_hash[:captures].first[:capture].deep_stringify_keys!.except('created_at'))
+    end
+  end
+
+  shared_examples 'unsuccessful refund' do
+    it 'returns an unsuccessful ActiveMerchant::Billing::Response and don`t add refund to order`s flow_data' do
+      expect(@result).to be_instance_of(ActiveMerchant::Billing::Response)
+      expect(@result.message).to eql('Some error')
+      expect(@result.success?).to eql(false)
+    end
+  end
+
   describe '#refund' do
     let(:order) { create(:order_with_line_items) }
     let(:payment_auth) { build(:flow_authorization_reference) }
@@ -21,38 +53,25 @@ RSpec.describe Spree::Gateway::FlowIo do
     context 'when refund has succeeded' do
       before do
         allow(FlowcommerceSpree).to receive_message_chain(:client, :refunds, :post).and_return(refund)
-      end
-
-      it 'returns a successful response, ads refund to the order`s flow_data, creates negative amount payment' do
         allow(gateway).to receive(:add_refund_to_order).and_call_original
         allow(gateway).to receive(:map_refund_to_payment).and_call_original
-
         expect(gateway).to receive(:add_refund_to_order).with(refund, order)
-        expect(gateway).to receive(:map_refund_to_payment).with(refund, order)
+        expect(gateway).to receive(:map_refund_to_payment)
 
-        result = nil
-        expect { result = gateway.refund(payment, amount) }.to change { Spree::Payment.count }.from(1).to(2)
+        @result = nil
+        expect { @result = gateway.refund(payment, amount) }.to change { Spree::Payment.count }.from(1).to(2)
+      end
 
-        expect(result).to be_instance_of(ActiveMerchant::Billing::Response)
-        expect(result.message).to eql(Spree::Gateway::FlowIo::REFUND_SUCCESS)
-        expect(result.success?).to eql(true)
+      it_behaves_like 'successful refund'
 
-        order.reload
-        order_refunds = order.flow_data['refunds']
-        expect(order_refunds).to be_instance_of(Array)
+      it 'returns a successful response' do
+        expect(@result).to be_instance_of(ActiveMerchant::Billing::Response)
+        expect(@result.message).to eql(Spree::Gateway::FlowIo::REFUND_SUCCESS)
+        expect(@result.success?).to eql(true)
+      end
 
-        order_refund = order_refunds.first
-        order_refund_captures = order_refund.delete('captures')
-        expect(order_refund_captures).to be_instance_of(Array)
-
-        refund_capture = order_refund_captures.first['capture']
-        expect(order_refund.except('created_at'))
-          .to eql(refund.to_hash.except(:captures, :created_at).deep_stringify_keys!)
-        expect(refund_capture.except('created_at'))
-          .to eql(refund.to_hash[:captures].first[:capture].deep_stringify_keys!.except('created_at'))
-
+      it 'creates negative amount payment' do
         created_payment = Spree::Payment.find_by(identifier: refund.id)
-
         expect(created_payment.amount).to eql(- amount)
       end
     end
@@ -61,18 +80,43 @@ RSpec.describe Spree::Gateway::FlowIo do
       before do
         allow(FlowcommerceSpree)
           .to receive_message_chain(:client, :refunds, :post).and_raise(StandardError, 'Some error')
-      end
-
-      it 'returns an unsuccessful ActiveMerchant::Billing::Response and don`t add refund to order`s flow_data' do
         allow(gateway).to receive(:add_refund_to_order).and_call_original
         expect(gateway).not_to receive(:add_refund_to_order)
-
-        result = gateway.refund(payment, amount)
-
-        expect(result).to be_instance_of(ActiveMerchant::Billing::Response)
-        expect(result.message).to eql('Some error')
-        expect(result.success?).to eql(false)
+        @result = gateway.refund(payment, amount)
       end
+
+      it_behaves_like 'unsuccessful refund'
+    end
+  end
+
+  describe '#credit' do
+    let(:order) { create(:order_with_line_items) }
+    let(:payment_auth) { build(:flow_authorization_reference) }
+    let!(:payment) { create(:payment, order: order, payment_method_id: gateway.id, response_code: payment_auth.id) }
+    let(:amount) { order.item_total }
+    let(:refund) { build(:flow_refund, currency: order.currency, amount: amount, authorization: payment_auth) }
+
+    context 'when credit has succeeded' do
+      before do
+        allow(FlowcommerceSpree).to receive_message_chain(:client, :refunds, :post).and_return(refund)
+        allow(gateway).to receive(:add_refund_to_order).and_call_original
+        expect(gateway).to receive(:add_refund_to_order).with(refund, order)
+        @result = gateway.credit(payment, amount)
+      end
+
+      it_behaves_like 'successful refund'
+    end
+
+    context 'when credit has failed' do
+      before do
+        allow(FlowcommerceSpree)
+          .to receive_message_chain(:client, :refunds, :post).and_raise(StandardError, 'Some error')
+        allow(gateway).to receive(:add_refund_to_order).and_call_original
+        expect(gateway).not_to receive(:add_refund_to_order)
+        @result = gateway.credit(payment, amount)
+      end
+
+      it_behaves_like 'unsuccessful refund'
     end
   end
 end


### PR DESCRIPTION
### What problem is the code solving?
When trying to create a new return we are getting an error. The reason behind it is because FlowIo gateway does not have the **credit** method specified.

### How does this change address the problem?
- Setting `payment_profiles_supported?` to return false.
- Adding new `Spree::Gateway::FlowIo#credit`. The method reuses part of the refund's logic. In order to follow the same logic as other gateways, this credit method should not create a transaction, but relay on the `Payment::Processing#credit!` to do it instead.
- Updating `Spree::Gateway::FlowIo#map_refund_to_payment` to set the source as the original payment (for consistency with other payments)

### Why is this the best solution?
- The reason to configure `payment_profiles_supported?` to return false is because within the `Payment::Processing#credit!` Spree is sending different params depending on this value when calling the Gateway's credit method. If we want to keep that param as true we will need to also update other Gateways's credit parameters since we need to pass a reference to the order to retrieve orders' data (Eg: CreditCardProfile). 
- Adding new `Spree::Gateway::FlowIo#credit`. The method reuses part of the refund's logic. In order to follow the same logic as other gateways, this credit method should not create a transaction, but relay on the `Payment::Processing#credit!` to do it instead.

### Share the knowledge