### PR TITLE
[DL-517] Updating OrderSync#add_item method to send variant price instead of cost_price

### DIFF
--- a/app/services/flowcommerce_spree/order_sync.rb
+++ b/app/services/flowcommerce_spree/order_sync.rb
@@ -124,7 +124,7 @@ module FlowcommerceSpree
       { center: FLOW_CENTER,
         number: variant.sku,
         quantity: line_item.quantity,
-        price: { amount: price_root['amount'] || variant.cost_price,
+        price: { amount: price_root['amount'] || variant.price,
                  currency: price_root['currency'] || variant.cost_currency } }
     end
 

--- a/spec/services/flowcommerce_spree/order_sync_spec.rb
+++ b/spec/services/flowcommerce_spree/order_sync_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe FlowcommerceSpree::OrderSync do
             let(:line_item) { order.line_items.first }
             let(:order_line_item) do
               { number: line_item.variant.sku,
-                price: { amount: line_item.variant.cost_price,
+                price: { amount: line_item.variant.price,
                          currency: line_item.variant.cost_currency },
                 center: FlowcommerceSpree::OrderSync::FLOW_CENTER,
                 quantity: order.line_items.size }


### PR DESCRIPTION
### What problem is the code solving?
There is a very specific scenario where if a product with variants has a master variant with flow data, but none of it's variants has flow data, when the user adds the product to the cart and goes to the Flow's checkout it will be charge the variant's `cost_price` instead of the price.

### How does this change address the problem?
Changing the default value sent when redirecting the user to the Flow's checkout to use the variant's price instead of the cost_price.

### Why is this the best solution?
This should not be the final solution though. Probably we can avoid allowing the user to add the product to the cart (or showing the variant / PDP) when no flow price is present. But I would tackle that improvement separately to this simple change.

This change is not the best either, but it is better than charging the cost_price if for some reason the scenario happens. 

### Share the knowledge
