### PR TITLE
[AD-681] Add all_prices method to variant decorator

### DIFF
--- a/app/models/spree/flow_io_variant_decorator.rb
+++ b/app/models/spree/flow_io_variant_decorator.rb
@@ -5,6 +5,9 @@
 # hold all important Flow sync data for specific experiences.
 module Spree
   module FlowIoVariantDecorator
+
+    REST_OF_WORLD = 'ROW'
+
     def self.prepended(base)
       base.serialize :meta, ActiveRecord::Coders::JSON.new(symbolize_keys: true)
 
@@ -171,7 +174,7 @@ module Spree
     end
 
     def add_prices_to_countries(prices, countries, zone_countries)
-      zone_countries.empty? ? countries["ROW"] = prices : add_prices_for_each_country(zone_countries, prices, countries)
+      zone_countries.empty? ? countries[REST_OF_WORLD] = prices : add_prices_for_each_country(zone_countries, prices, countries)
     end
 
     def add_prices_for_each_country(zone_countries, prices, countries)

--- a/app/models/spree/flow_io_variant_decorator.rb
+++ b/app/models/spree/flow_io_variant_decorator.rb
@@ -173,8 +173,11 @@ module Spree
     end
 
     def add_prices_to_countries(prices, countries, zone_countries)
-      zone_countries.empty? ? countries[REST_OF_WORLD] = prices
-        : add_prices_for_each_country(zone_countries, prices, countries)
+      if zone_countries.empty?
+        countries[REST_OF_WORLD] = prices
+      else
+        add_prices_for_each_country(zone_countries, prices, countries)
+      end
     end
 
     def add_prices_for_each_country(zone_countries, prices, countries)

--- a/app/models/spree/flow_io_variant_decorator.rb
+++ b/app/models/spree/flow_io_variant_decorator.rb
@@ -5,7 +5,6 @@
 # hold all important Flow sync data for specific experiences.
 module Spree
   module FlowIoVariantDecorator
-
     REST_OF_WORLD = 'ROW'
 
     def self.prepended(base)
@@ -174,7 +173,8 @@ module Spree
     end
 
     def add_prices_to_countries(prices, countries, zone_countries)
-      zone_countries.empty? ? countries[REST_OF_WORLD] = prices : add_prices_for_each_country(zone_countries, prices, countries)
+      zone_countries.empty? ? countries[REST_OF_WORLD] = prices
+        : add_prices_for_each_country(zone_countries, prices, countries)
     end
 
     def add_prices_for_each_country(zone_countries, prices, countries)

--- a/app/models/spree/flow_io_variant_decorator.rb
+++ b/app/models/spree/flow_io_variant_decorator.rb
@@ -142,10 +142,8 @@ module Spree
       countries = {}
 
       zones.each do |zone|
-        all_prices = []
-
-        add_prices_for_available_currencies(zone, all_prices)
-        add_prices_to_countries(all_prices, countries, zone.countries) unless all_prices.empty?
+        prices = create_prices_for_available_currencies(zone)
+        add_prices_to_countries(prices, countries, zone.countries) unless prices.empty?
 
         flow_experience_key = zone&.flow_io_experience
         next if flow_experience_key.blank?
@@ -154,36 +152,6 @@ module Spree
       end
 
       countries
-    end
-
-    def add_prices_for_available_currencies(zone, all_prices)
-      zone.available_currencies.each do |currency|
-        price = prices.find_by(currency: currency)
-        all_prices << parse_price(price) unless price.nil?
-      end
-    end
-
-    def add_flow_prices(flow_experience_key, countries, country_iso)
-      flow_price = flow_local_price(flow_experience_key)
-      countries[country_iso] = parse_price(flow_price)
-    end
-
-    def parse_price(price)
-      { currency: price.currency, amount: (price.amount&.round || 0).to_s }
-    end
-
-    def add_prices_to_countries(prices, countries, zone_countries)
-      if zone_countries.empty?
-        countries[REST_OF_WORLD] = prices
-      else
-        add_prices_for_each_country(zone_countries, prices, countries)
-      end
-    end
-
-    def add_prices_for_each_country(zone_countries, prices, countries)
-      zone_countries.each do |country|
-        countries[country.iso] = prices
-      end
     end
 
     # creates object for flow api
@@ -261,5 +229,41 @@ module Spree
     end
 
     Spree::Variant.prepend(self) if Spree::Variant.included_modules.exclude?(self)
+
+    private
+
+    def create_prices_for_available_currencies(zone)
+      all_prices = []
+
+      zone.available_currencies.each do |currency|
+        price = prices.find_by(currency: currency)
+        all_prices << parse_price(price) unless price.nil?
+      end
+
+      all_prices
+    end
+
+    def add_prices_to_countries(prices, countries, zone_countries)
+      if zone_countries.empty?
+        countries[REST_OF_WORLD] = prices
+      else
+        add_prices_for_each_country(zone_countries, prices, countries)
+      end
+    end
+
+    def add_prices_for_each_country(zone_countries, prices, countries)
+      zone_countries.each do |country|
+        countries[country.iso] = prices
+      end
+    end
+
+    def add_flow_prices(flow_experience_key, countries, country_iso)
+      flow_price = flow_local_price(flow_experience_key)
+      countries[country_iso] = parse_price(flow_price)
+    end
+
+    def parse_price(price)
+      { currency: price.currency, amount: (price.amount&.round || 0).to_s }
+    end
   end
 end

--- a/lib/flowcommerce_spree/version.rb
+++ b/lib/flowcommerce_spree/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlowcommerceSpree
-  VERSION = '0.0.5'
+  VERSION = '0.0.12'
 end

--- a/spec/factories/spree/spree_zones.rb
+++ b/spec/factories/spree/spree_zones.rb
@@ -70,7 +70,7 @@ FactoryBot.define do
 
         trait :with_currencies do
           after(:create) do |zone|
-            zone.currencies = ["USD"]
+            zone.currencies = ['USD']
           end
         end
       end

--- a/spec/factories/spree/spree_zones.rb
+++ b/spec/factories/spree/spree_zones.rb
@@ -67,6 +67,12 @@ FactoryBot.define do
 
       factory :product_zone_with_country, class: Spree::Zones::Product do
         description { "Description for Product Zone #{name}" }
+
+        trait :with_currencies do
+          after(:create) do |zone|
+            zone.currencies = ["USD"]
+          end
+        end
       end
 
       factory :product_zone_with_flow_experience, class: Spree::Zones::Product do

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -138,6 +138,34 @@ RSpec.describe Spree::Variant, type: :model do
     end
   end
 
+  describe '#all_prices' do
+    describe 'when variant has flow_data' do
+      let(:variant) { create(:base_variant, :with_flow_data) }
+
+      context 'when zone has flow_io experience' do
+        it 'includes flow_io price' do
+          spree_zone = create(:germany_zone, :with_flow_data)
+          all_prices = variant.all_prices([spree_zone])
+
+          flow_price = variant.flow_local_price('germany')
+          expect(all_prices["DEU"]).to(include(amount: flow_price.amount.round.to_s, currency: flow_price.currency))
+        end
+      end
+    end
+
+    context 'when variant does not have flow_data' do
+      let(:variant) { create(:base_variant) }
+
+      it 'returns all_prices' do
+        zone = create(:product_zone_with_country, :with_currencies)
+        all_prices = variant.all_prices([zone])
+
+        country_iso = zone.countries.first.iso
+        expect(all_prices[country_iso]).to(eq([{ amount: variant.price.round.to_s, currency: 'USD' }]))
+      end
+    end
+  end
+
   describe '#sync_product_to_flow' do
     let(:variant) { create(:base_variant, :with_flow_data) }
 

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Spree::Variant, type: :model do
           all_prices = variant.all_prices([spree_zone])
 
           flow_price = variant.flow_local_price('germany')
-          expect(all_prices["DEU"]).to(include(amount: flow_price.amount.round.to_s, currency: flow_price.currency))
+          expect(all_prices['DEU']).to(include(amount: flow_price.amount.round.to_s, currency: flow_price.currency))
         end
       end
     end


### PR DESCRIPTION
### What problem is the code solving?
- We add this new method to return variant prices information in a way that is useful for then indexing these variants in Algolia.

### How does this change address the problem?
- Returning variant price information for each country.

### Why is this the best solution?

### Share the knowledge
