### PR TITLE
[DL-614] Adding support to include country_locale within the redirection routes when synchronizing order with Flow

### DIFF
--- a/app/controllers/flowcommerce_spree/orders_controller.rb
+++ b/app/controllers/flowcommerce_spree/orders_controller.rb
@@ -14,7 +14,11 @@ module FlowcommerceSpree
       flow_updater = FlowcommerceSpree::OrderUpdater.new(order: order)
       flow_updater.complete_checkout
 
-      redirect_to "/thankyou?order=#{params[:order]}&t=#{params[:t]}"
+      redirection_path = "/thankyou?order=#{params[:order]}&t=#{params[:t]}"
+      locale = order.locale_path
+      redirection_path = "/#{locale}#{redirection_path}" if locale
+
+      redirect_to redirection_path
     end
   end
 end

--- a/app/services/flowcommerce_spree/order_sync.rb
+++ b/app/services/flowcommerce_spree/order_sync.rb
@@ -54,19 +54,20 @@ module FlowcommerceSpree
     end
 
     def refresh_checkout_token
-      root_url = Rails.application.routes.url_helpers.root_url
       order_number = @order.number
+      root_url = Rails.application.routes.url_helpers.root_url
+      root_url_with_locale = "#{root_url}#{@order.try(:locale_path)}"
       confirmation_url = "#{root_url}flow/order-completed?order=#{order_number}&t=#{@order.guest_token}"
       @order.flow_io_attribute_add('flow_return_url', confirmation_url)
-      @order.flow_io_attribute_add('checkout_continue_shopping_url', root_url)
+      @order.flow_io_attribute_add('checkout_continue_shopping_url', root_url_with_locale)
 
       FlowcommerceSpree.client.checkout_tokens.post_checkout_and_tokens_by_organization(
         FlowcommerceSpree::ORGANIZATION, discriminator: 'checkout_token_reference_form',
                                          order_number: order_number,
                                          session_id: @flow_session_id,
-                                         urls: { continue_shopping: root_url,
+                                         urls: { continue_shopping: root_url_with_locale,
                                                  confirmation: confirmation_url,
-                                                 invalid_checkout: root_url }
+                                                 invalid_checkout: root_url_with_locale }
       )&.id
     end
 

--- a/lib/flowcommerce_spree/version.rb
+++ b/lib/flowcommerce_spree/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlowcommerceSpree
-  VERSION = '0.0.5'
+  VERSION = '0.0.12'
 end

--- a/spec/controllers/flowcommerce_spree/orders_controller_spec.rb
+++ b/spec/controllers/flowcommerce_spree/orders_controller_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe FlowcommerceSpree::OrdersController, type: :controller do
         expect(subject).to(redirect_to("/thankyou?order=#{order.number}&t=#{order.guest_token}"))
       end
 
+      context 'when order has locale' do
+        let(:locale_path) { 'de/de' }
+        before do
+          allow_any_instance_of(Spree::Order).to(receive(:locale_path).and_return(locale_path))
+        end
+
+        it 'redirects to thank you page with locale' do
+          expect(subject).to(redirect_to("/#{locale_path}/thankyou?order=#{order.number}&t=#{order.guest_token}"))
+        end
+      end
+
       context 'when order params are not present' do
         let(:params) { {} }
 

--- a/spec/dummy/app/models/spree/order_decorator.rb
+++ b/spec/dummy/app/models/spree/order_decorator.rb
@@ -18,6 +18,8 @@ module Spree
       # rubocop:enable Naming/MemoizedInstanceVariableName
     end
 
+    def locale_path; end
+
     def shipment
       shipments.first
     end


### PR DESCRIPTION
### What problem is the code solving?
We want to share the order's locale with Flow so when the user is redirected back to the Store they will keep the selected preference.

### How does this change address the problem?
- Extending the `OrderSync` to include the order's locale when creating the redirection urls.
- Updating the `FlowcommerceSpree::OrdersController#order_completed` endpoint to include the order's locale within the thank you page url when redirecting the user. 

### Why is this the best solution?
This is the simplest solution so far, since it requires very little changes.

### Share the knowledge
The order's `Spree::Order#locale_path` implementation will be included in the main app and will return the order's stored locale. 