### PR TITLE
[DL-614] Avoid prepare_order and before_render within order_completed endpoint.

### DIFF
--- a/app/controllers/flowcommerce_spree/orders_controller.rb
+++ b/app/controllers/flowcommerce_spree/orders_controller.rb
@@ -5,6 +5,8 @@ module FlowcommerceSpree
     wrap_parameters false
 
     skip_before_action :setup_tracking, only: :order_completed
+    skip_before_action :prepare_order
+    skip_before_action :before_render
 
     # proxy enpoint between flow and thankyou page.
     # /flow/order_completed endpoint


### PR DESCRIPTION
### What problem is the code solving?
When user completes Flow's checkout, it is being redirected to the this order_completed endpoint. At this point, the flow is broken due to the bag_order returning a nil object instead of an order.

### How does this change address the problem?
We don't need in this endpoint those actions, because of that I am completely avoiding them.

### Why is this the best solution?
We remove unnecessary code.

### Share the knowledge
