### PR TITLE
[DL-674] - Send promotion info to flow

### DIFF
--- a/app/services/flowcommerce_spree/order_updater.rb
+++ b/app/services/flowcommerce_spree/order_updater.rb
@@ -63,7 +63,8 @@ module FlowcommerceSpree
         payment.update_column(:identifier, p['id'])
       end
 
-      return if @order.payments.sum(:amount) < @order.amount || @order.state == 'complete'
+      return if @order.completed?
+      return if @order.payments.sum(:amount) < @order.flow_io_total_amount || @order.flow_io_balance_amount > 0
 
       @order.state = 'confirm'
       @order.save!

--- a/spec/factories/spree/spree_adjustment.rb
+++ b/spec/factories/spree/spree_adjustment.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+    factory :adjustment, class: Spree::Adjustment do
+      association(:adjustable, factory: :order)
+      label { 'test' }
+      amount { 100 }
+    end
+  
+    factory :promotion_adjustment, class: Spree::Adjustment do
+      association(:adjustable, factory: :line_item)
+      amount { -10.0 }
+      label 'Promotion'
+      association(:source, factory: :per_item_promotion_action)
+      eligible true
+    end
+end

--- a/spec/factories/spree/spree_adjustment.rb
+++ b/spec/factories/spree/spree_adjustment.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-    factory :adjustment, class: Spree::Adjustment do
-      association(:adjustable, factory: :order)
-      label { 'test' }
-      amount { 100 }
-    end
-  
-    factory :promotion_adjustment, class: Spree::Adjustment do
-      association(:adjustable, factory: :line_item)
-      amount { -10.0 }
-      label 'Promotion'
-      association(:source, factory: :per_item_promotion_action)
-      eligible true
-    end
+  factory :adjustment, class: Spree::Adjustment do
+    association(:adjustable, factory: :order)
+    label { 'test' }
+    amount { 100 }
+  end
+
+  factory :promotion_adjustment, class: Spree::Adjustment do
+    association(:adjustable, factory: :line_item)
+    amount { -10.0 }
+    label 'Promotion'
+    association(:source, factory: :per_item_promotion_action)
+    eligible true
+  end
 end

--- a/spec/factories/spree/spree_promotion.rb
+++ b/spec/factories/spree/spree_promotion.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-    factory :promotion, class: Spree::Promotion do
-      name { 'test' }
-      description { 'description' }
+  factory :promotion, class: Spree::Promotion do
+    name { 'test' }
+    description { 'description' }
+  end
+
+  trait :with_order_adjustment do
+    transient do
+      order_adjustment_amount { 10 }
     end
-  
-    trait :with_order_adjustment do
-      transient do
-        order_adjustment_amount { 10 }
-      end
-  
-      after(:create) do |promotion, evaluator|
-        calculator = Spree::Calculator::FlatRate.new
-        calculator.preferred_amount = evaluator.order_adjustment_amount
-        action = Spree::Promotion::Actions::CreateAdjustment.create!(calculator: calculator)
-        promotion.actions << action
-        promotion.save!
-      end
+
+    after(:create) do |promotion, evaluator|
+      calculator = Spree::Calculator::FlatRate.new
+      calculator.preferred_amount = evaluator.order_adjustment_amount
+      action = Spree::Promotion::Actions::CreateAdjustment.create!(calculator: calculator)
+      promotion.actions << action
+      promotion.save!
     end
+  end
 end

--- a/spec/factories/spree/spree_promotion.rb
+++ b/spec/factories/spree/spree_promotion.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+    factory :promotion, class: Spree::Promotion do
+      name { 'test' }
+      description { 'description' }
+    end
+  
+    trait :with_order_adjustment do
+      transient do
+        order_adjustment_amount { 10 }
+      end
+  
+      after(:create) do |promotion, evaluator|
+        calculator = Spree::Calculator::FlatRate.new
+        calculator.preferred_amount = evaluator.order_adjustment_amount
+        action = Spree::Promotion::Actions::CreateAdjustment.create!(calculator: calculator)
+        promotion.actions << action
+        promotion.save!
+      end
+    end
+end

--- a/spec/factories/spree/spree_promotions_actions.rb
+++ b/spec/factories/spree/spree_promotions_actions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+    factory :promotion_action, class: Spree::PromotionAction do
+    end
+  
+    factory :per_item_promotion_action, class: Spree::Promotion::Actions::CreateItemAdjustments do
+      association(:promotion, factory: :promotion, strategy: :build)
+    end
+end

--- a/spec/factories/spree/spree_promotions_actions.rb
+++ b/spec/factories/spree/spree_promotions_actions.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-    factory :promotion_action, class: Spree::PromotionAction do
-    end
-  
-    factory :per_item_promotion_action, class: Spree::Promotion::Actions::CreateItemAdjustments do
-      association(:promotion, factory: :promotion, strategy: :build)
-    end
+  factory :promotion_action, class: Spree::PromotionAction do
+  end
+
+  factory :per_item_promotion_action, class: Spree::Promotion::Actions::CreateItemAdjustments do
+    association(:promotion, factory: :promotion, strategy: :build)
+  end
 end

--- a/spec/services/flowcommerce_spree/order_sync_spec.rb
+++ b/spec/services/flowcommerce_spree/order_sync_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe FlowcommerceSpree::OrderSync do
             let(:line_item) { order.line_items.first }
             let(:order_line_item) do
               { number: line_item.variant.sku,
+                discounts: { discounts: [] },
                 price: { amount: line_item.variant.price,
                          currency: line_item.variant.cost_currency },
                 center: FlowcommerceSpree::OrderSync::FLOW_CENTER,
@@ -114,6 +115,32 @@ RSpec.describe FlowcommerceSpree::OrderSync do
                 .with(FlowcommerceSpree::ORGANIZATION,
                       order.number, order_put_form, expand: ['experience'], experience: order.flow_io_experience_key)
               expect(instance).to receive(:refresh_checkout_token)
+            end
+
+            context 'has promotions on line_items' do
+              let(:line_item) { create(:line_item) }
+              let(:order_put_form) { build(:flow_order_put_form, items: [line_item_form]) }
+              let(:expected_result) do
+                { center: FLOW_CENTER,
+                  number: variant.sku,
+                  quantity: line_item.quantity,
+                  price: { amount: line_item.variant.price,
+                           currency: line_item.variant.cost_currency },
+                  discounts: [{ offer: { discriminator: 'discount_offer_fixed',
+                                         money: { amount: 0.0, currency: 'USD' } },
+                                target: 'item', label: 'Promotion' }] }
+              end
+              before do
+                allow(instance).to receive(:add_item).and_call_original
+                line_item.adjustments << create(:promotion_adjustment,
+                                                adjustable: line_item, order: line_item.order)
+              end
+
+              it 'adds discounts to flow payload' do
+                expect(instance).to receive(:add_item).and_return(:expected_result)
+
+                instance.synchronize!
+              end
             end
 
             context 'has locale set' do

--- a/spec/services/flowcommerce_spree/order_updater_spec.rb
+++ b/spec/services/flowcommerce_spree/order_updater_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe FlowcommerceSpree::OrderUpdater do
 
       context 'when payments amount is less than order`s amount' do
         it 'does not call finalize_order if order is not updated to`complete`' do
+          allow(order).to(receive(:flow_io_total_amount).and_return(order.payments.sum(:amount) + 1))
           expect_any_instance_of(FlowcommerceSpree::OrderUpdater).not_to(receive(:finalize_order))
           subject.new(order: order).complete_checkout
         end
@@ -132,6 +133,7 @@ RSpec.describe FlowcommerceSpree::OrderUpdater do
       context 'when there is no flow payments information' do
         it 'does not update order as complete' do
           allow(order).to(receive(:flow_io_payments).and_return([]))
+          allow(order).to(receive(:flow_io_total_amount).and_return(100))
           subject.new(order: order).map_payments_to_spree
 
           expect(order.complete?).to(be_falsey)


### PR DESCRIPTION
### What problem is the code solving?

In order to support BFCM promotions in flow, we need to send the discounts information to them so they can show it in the checkout

### How does this change address the problem?

Map the discount data to the payload sent to flow