### PR TITLE
[DL-874] change on adjust_zone_and_ip method to avoid updating last_ip_address almost allways, and instead only when needed

### DIFF
--- a/app/helpers/spree/core/controller_helpers/flow_io_order_helper_decorator.rb
+++ b/app/helpers/spree/core/controller_helpers/flow_io_order_helper_decorator.rb
@@ -27,7 +27,7 @@ module Spree
           attrs_to_update = {}
 
           # Update last_ip_address only when last_ip_address is different.
-          attrs_to_update = { last_ip_address: ip_address } if @curren_order.last_ip_address != ip_address
+          attrs_to_update = { last_ip_address: ip_address } if @current_order.last_ip_address != ip_address
 
           # :meta is a jsonb column costly to update every time, especially with all the flow.io data, that's why
           # here it is updated only if no zone_id there was inside :meta

--- a/app/helpers/spree/core/controller_helpers/flow_io_order_helper_decorator.rb
+++ b/app/helpers/spree/core/controller_helpers/flow_io_order_helper_decorator.rb
@@ -26,8 +26,8 @@ module Spree
 
           attrs_to_update = {}
 
-          # Update last_ip_address only for a new request_id
-          attrs_to_update = { last_ip_address: ip_address } if @request_id != request_id
+          # Update last_ip_address only when last_ip_address is different.
+          attrs_to_update = { last_ip_address: ip_address } if @curren_order.last_ip_address != ip_address
 
           # :meta is a jsonb column costly to update every time, especially with all the flow.io data, that's why
           # here it is updated only if no zone_id there was inside :meta


### PR DESCRIPTION
### What problem is the code solving?
From time to time we are having issues with the session_current. This is because it is calling this method `adjust_zone_and_ip` which is updating almost always the last_ip_address. 

### How does this change address the problem?
Changing code to only update `last_ip_address` when it is different from what it is stored.

### Why is this the best solution?
Will get us less updates to the database each time it is called. 

### Share the knowledge
