### PR TITLE
[UDL-760] - Fixed klarna payment sync for flow orders

### DIFF
--- a/app/services/flowcommerce_spree/webhooks/capture_upserted_v2.rb
+++ b/app/services/flowcommerce_spree/webhooks/capture_upserted_v2.rb
@@ -36,8 +36,7 @@ module FlowcommerceSpree
 
       def store_payment_capture(order, capture)
         upsert_order_captures(order, capture)
-        payments = order.flow_io_payments
-        map_payment_captures_to_spree(order, payments) if payments.present?
+        map_payment_captures_to_spree(order)
         order
       end
 
@@ -52,9 +51,11 @@ module FlowcommerceSpree
         order.update_column(:meta, order.meta.to_json)
       end
 
-      def map_payment_captures_to_spree(order, payments)
+      def map_payment_captures_to_spree(order)
+        payments = order.flow_io_payments
         order.flow_data['captures']&.each do |c|
-          next unless (payment = captured_payment(payments, c, order))
+          payment = payments ? captured_payment(payments, c, order) : placeholder_captured_payment(order)
+          return unless payment
 
           payment.capture_events.create!(amount: c['amount'], meta: { 'flow_data' => { 'id' => c['id'] } })
           return if payment.completed? || payment.capture_events.sum(:amount) < payment.amount
@@ -68,17 +69,10 @@ module FlowcommerceSpree
         FlowcommerceSpree::OrderUpdater.new(order: order).finalize_order
       end
 
-      def captured_payment(flow_order_payments, capture, order)
+      def captured_payment(flow_order_payments, capture, _order)
         return unless capture['status'] == 'succeeded'
-        auth = capture.dig('authorization', 'id')
-        payment = order.payments.first
 
-        if flow_order_payments.blank? && payment.response_code.blank?
-          payment.response_code = capture.dig('authorization', 'key')
-          payment.identifier = capture.dig('authorization', 'key')
-          payment.save
-          return payment
-        end
+        auth = capture.dig('authorization', 'id')
 
         return unless flow_order_payments&.find { |p| p['reference'] == auth }
 
@@ -86,6 +80,17 @@ module FlowcommerceSpree
 
         return if Spree::PaymentCaptureEvent.where("meta -> 'flow_data' ->> 'id' = ?", capture['id']).exists?
 
+        payment
+      end
+
+      def placeholder_captured_payment(order)
+        payment = order.payments.first
+
+        if flow_order_payments.blank? && payment.response_code.blank?
+          payment.response_code = capture.dig('authorization', 'key')
+          payment.identifier = capture.dig('authorization', 'key')
+          payment.save
+        end
         payment
       end
     end

--- a/lib/flowcommerce_spree/version.rb
+++ b/lib/flowcommerce_spree/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlowcommerceSpree
-  VERSION = '0.0.19'
+  VERSION = '0.0.21'
 end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Users::SessionsController, type: :controller do
 
           expect(response).to have_http_status(:success)
           expect(Oj.load(response.body))
-            .to eql('checkout_url' => "https://checkout.mejuri.com/tokens/#{checkout_token.id}")
+            .to eql('checkout_url' => "https://checkout.flow.io/tokens/#{checkout_token.id}")
         end
       end
 

--- a/spec/factories/flow_io/order_address.rb
+++ b/spec/factories/flow_io/order_address.rb
@@ -3,7 +3,12 @@
 FactoryBot.define do
   factory :flow_order_address, class: Io::Flow::V0::Models::OrderAddress do
     country { Faker::Address.country_code }
-
+    streets { %w[fake1 fake2] }
+    contact { { 'name': { 'first': 'fake', 'last': 'fake last' }, 'phone': '123' } }
+    phone { '123457' }
+    postal { '123' }
+    city { 'test city' }
+    province { 'test state' }
     initialize_with { new(**attributes) }
   end
 end

--- a/spec/factories/spree/spree_payment_method.rb
+++ b/spec/factories/spree/spree_payment_method.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :payment_method, class: Spree::PaymentMethod do
+    description { '' }
+    active { true }
+    environment { 'test' }
+    deleted_at { nil }
+    display_on { 'both' }
+    auto_capture { nil }
+    publishable_key { 'pk_test_lOqm7Kap09Mb3VT2N3teqV4v' }
+    private_key { 'sk_test_r4ZQWVq4juSTx6jkrXfNFvBT' }
+    name { 'stripe-ca' }
+
+    factory :spree_payment_method_flow do
+      name { 'flow_io' }
+      type { 'Spree::Gateway::FlowIo' }
+    end
+  end
+end

--- a/spec/factories/spree/spree_payments.rb
+++ b/spec/factories/spree/spree_payments.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :payment, class: Spree::Payment do
     order
+    payment_method { create(:spree_payment_method_flow) }
     response_code { Faker::Guid.guid }
   end
 

--- a/spec/services/flowcommerce_spree/order_updater_spec.rb
+++ b/spec/services/flowcommerce_spree/order_updater_spec.rb
@@ -86,7 +86,11 @@ RSpec.describe FlowcommerceSpree::OrderUpdater do
     end
 
     describe '#complete_checkout' do
+      let(:payment_method) { create(:spree_payment_method_flow) }
+      let(:order_payment) { create(:payment, :completed) }
       before do
+        order.payments << order_payment
+        allow(Spree::PaymentMethod).to receive(:find_by).and_return(payment_method)
         expect_any_instance_of(FlowcommerceSpree::OrderUpdater).to(receive(:upsert_data))
         expect_any_instance_of(FlowcommerceSpree::OrderUpdater).to(receive(:map_payments_to_spree)).and_call_original
       end

--- a/spec/services/flowcommerce_spree/order_updater_spec.rb
+++ b/spec/services/flowcommerce_spree/order_updater_spec.rb
@@ -131,12 +131,13 @@ RSpec.describe FlowcommerceSpree::OrderUpdater do
       end
 
       context 'when there is no flow payments information' do
-        it 'does not update order as complete' do
+        it 'does updates order as complete with placeholder payment' do
           allow(order).to(receive(:flow_io_payments).and_return([]))
           allow(order).to(receive(:flow_io_total_amount).and_return(100))
           subject.new(order: order).map_payments_to_spree
 
-          expect(order.complete?).to(be_falsey)
+          expect(order.complete?).to(be_truthy)
+          expect(order.payments.first.response_code).to be(nil)
         end
       end
     end


### PR DESCRIPTION
### What problem is the code solving?
There is an issue with the sync of klarna payments with the new logic of placeholder payment. The validation was over the flow payments instead of the order payments, so it was still ignoring the captured upserted event.
### How does this change address the problem?
Removes the validation for flow payments and improves the code
